### PR TITLE
Running tests now produce junit xml artifacts.

### DIFF
--- a/pharo/run.sh
+++ b/pharo/run.sh
@@ -89,5 +89,5 @@ Metacello new
 "
 
 print_info "Run tests..."
-$PHARO_VM "$SMALLTALK_CI_BUILD/$PHARO_IMAGE" test --fail-on-failure "$TESTS" 2>&1 || EXIT_STATUS=$?
+$PHARO_VM "$SMALLTALK_CI_BUILD/$PHARO_IMAGE" test --junit-xml-output --fail-on-failure "$TESTS" 2>&1 || EXIT_STATUS=$?
 # ==============================================================================


### PR DESCRIPTION
The default test output is not particularly great, partially because Pharo uses CR as line separators, so the output tends to overlap.

However the test runner can produce junit xml artifact... pretty much a universal output across languages and tools.