### PR TITLE
Fix the default config by using 'loading' and not 'loadSpecs'

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -253,7 +253,7 @@ check_backward_compatibility() {
 
     cat >${config_project_home}/${SMALLTALK_CI_DEFAULT_CONFIG} <<EOL
 SmalltalkCISpec {
-  #loadSpecs : [
+  #loading : [
       SCIMetacelloLoadSpec {
           #baseline : '${BASELINE}',
           #directory : '${PACKAGES}',


### PR DESCRIPTION
In 5c16ba63b092de2f0debca406644be426a678557 the loadSpecs got
renamed to loading but the default file generation has not been
updated.