### PR TITLE
Infrastructure for GemStone-specific eun.sh args

### DIFF
--- a/gemstone/run.sh
+++ b/gemstone/run.sh
@@ -10,6 +10,26 @@ local PHARO_IMAGE_FILE="Pharo-3.0.image"
 local PHARO_CHANGES_FILE="Pharo-3.0.changes"
 
 ################################################################################
+# Handle GemStone-specific options.
+################################################################################
+gemstone::parse_options() {
+  while :
+  do
+    case "$1" in
+      --gs-*)
+        print_error_and_exit "Unknown GemStone-specific option: $1"
+        ;;
+      "")
+        break
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+}
+
+################################################################################
 # Clone the GsDevKit_home project.
 ################################################################################
 gemstone::prepare_gsdevkit_home() {
@@ -171,6 +191,8 @@ EOF
 ################################################################################
 run_build() {
   local exit_status=0
+
+  gemstone::parse_options "$@"
 
   # Temporary fix for https://github.com/hpi-swa/smalltalkCI/issues/68
   case "$(uname -s)" in

--- a/run.sh
+++ b/run.sh
@@ -243,8 +243,8 @@ check_clean_up() {
   local question1="Are you sure you want to clear builds and cache? (y/N): "
   local question2="Continue with build progress? (y/N): "
   if [[ "${config_clean}" = "true" ]]; then
-    print_info "builds at '${SMALLTALK_CI_CACHE}'."
-    print_info "cache at '${SMALLTALK_CI_BUILD_BASE}'."
+    print_info "cache at '${SMALLTALK_CI_CACHE}'."
+    print_info "builds at '${SMALLTALK_CI_BUILD_BASE}'."
     read -p "${question1}" user_input
     if [[ "${user_input}" = "y" ]]; then
       clean_up

--- a/run.sh
+++ b/run.sh
@@ -110,6 +110,8 @@ parse_args() {
     exit 0
   fi
 
+  SCRIPT_ARGS=( "$*" )
+
   # Handle all arguments and flags
   while :
   do
@@ -120,6 +122,10 @@ parse_args() {
       ;;
     -d | --debug)
       config_debug="true"
+      shift
+      ;;
+    --gs-*)
+      # Reserved namespace for GemStone options
       shift
       ;;
     -h | --help)
@@ -215,6 +221,7 @@ clean_up() {
     print_info "Removing the following directories:"
     print_info "  ${SMALLTALK_CI_CACHE}"
     print_info "  ${SMALLTALK_CI_BUILD_BASE}"
+    chmod -fR +w  "${SMALLTALK_CI_CACHE}" "${SMALLTALK_CI_BUILD_BASE}"
     rm -rf "${SMALLTALK_CI_CACHE}" "${SMALLTALK_CI_BUILD_BASE}"
     print_info "Done."
   else
@@ -241,7 +248,7 @@ run() {
       ;;
     GemStone*)
       print_info "Starting GemStone build..."
-      source "${SMALLTALK_CI_HOME}/gemstone/run.sh"
+      source "${SMALLTALK_CI_HOME}/gemstone/run.sh" $SCRIPT_ARGS
       ;;
     *)
       print_error_and_exit "Unknown Smalltalk version '${config_smalltalk}'."
@@ -256,7 +263,7 @@ run() {
     travis_fold end display_config
   fi
 
-  run_build
+  run_build $SCRIPT_ARGS
   return $?
 }
 


### PR DESCRIPTION
- Remove the --gs-* args that don't apply quite yet
- Partial fix for Issue #102 - fix typos for the `--clean` messages
- changes needed to make the `--gs-*` args code fuctional ...
- fix a GemStone-only bug in `--clear`