### PR TITLE
expand gemstone client support to include pharo6.0

### DIFF
--- a/gemstone/run.sh
+++ b/gemstone/run.sh
@@ -165,6 +165,10 @@ gemstone::prepare_optional_clients() {
   for version in "${DEVKIT_CLIENTS[@]}"
   do
     case "${version}" in
+      "Pharo-6.0")
+        client_version="Pharo6.0"
+        client_extension="Pharo6.0"
+        ;;
       "Pharo-5.0")
         client_version="Pharo5.0"
         client_extension="Pharo5.0"


### PR DESCRIPTION
Adding support to GsDevKit_home for Pharo-6.0, so will need to update the gemstone/run.sh script to permit pharo6.0 clients