### PR TITLE
Pharo-alpha should also use the latest VM, not just the latest image

### DIFF
--- a/pharo/run.sh
+++ b/pharo/run.sh
@@ -76,7 +76,11 @@ pharo::get_vm_url() {
   local smalltalk_name=$1
 
   case "${smalltalk_name}" in
-    "Pharo-alpha"|"Pharo-6.0")
+    # NOTE: vmLatestXX should be updated every time new Pharo is released
+    "Pharo-alpha")
+      echo "get.pharo.org/vmLatest60"
+      ;;
+    "Pharo-6.0")
       echo "get.pharo.org/vm60"
       ;;
     "Pharo-stable"|"Pharo-5.0"|"Moose-6"*)

--- a/tests/pharo_tests.sh
+++ b/tests/pharo_tests.sh
@@ -39,7 +39,7 @@ test_get_vm_url() {
   local vm_url
 
   vm_url="$(pharo::get_vm_url "Pharo-alpha")"
-  assertEquals "get.pharo.org/vm60" "${vm_url}"
+  assertEquals "get.pharo.org/vmLatest60" "${vm_url}"
 
   vm_url="$(pharo::get_vm_url "Pharo-stable")"
   assertEquals "get.pharo.org/vm50" "${vm_url}"


### PR DESCRIPTION
Apparently this was also requested in https://github.com/hpi-swa/smalltalkCI/issues/274 (274 however also requests 64bit and threaded heartbeat, which this PR doesn't address)