### PR TITLE
Run Pharo images without default preferences

### DIFF
--- a/pharo/run.sh
+++ b/pharo/run.sh
@@ -233,7 +233,7 @@ pharo::run_script() {
     vm_flags="--no-quit"
   fi
 
-  travis_wait "${resolved_vm}" "${resolved_image}" eval ${vm_flags} "${script}"
+  travis_wait "${resolved_vm}" "${resolved_image}" --no-default-preferences eval ${vm_flags} "${script}"
 }
 
 ################################################################################


### PR DESCRIPTION
Pharo users can have special preferences that run on image startup. This introduces unexpected issues when trying to reproduce Smalltalk-CI behavior locally.