### PR TITLE
Added 64 bit support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ smalltalk:
   - Pharo-4.0
   - Pharo-3.0
 
+  - Pharo64-alpha
+  # - Pharo64-stable  # identical to Pharo64-6.0
+  - Pharo64-7.0
+  - Pharo64-6.0
+
   # - Moose-trunk   # identical to Moose-6.1
   - Moose-6.1
   - Moose-6.0

--- a/README.md
+++ b/README.md
@@ -67,16 +67,16 @@ they can take up a lot of space on your drive.*
 
 ## <a name="images"/>List Of Supported Images
 
-| [Squeak][squeak] | [Pharo][pharo] | [GemStone][gemstone] | [Moose][moose] |
-| ---------------- | -------------- | -------------------- | -------------- |
-| `Squeak-trunk`   | `Pharo-alpha`  | `GemStone-3.3.x`     | `Moose-trunk`  |
-| `Squeak-5.1`     | `Pharo-stable` | `GemStone-3.2.x`     | `Moose-6.1`    |
-| `Squeak-5.0`     | `Pharo-7.0`    | `GemStone-3.1.0.x`   | `Moose-6.0`    |
-| `Squeak-4.6`     | `Pharo-6.0`    | `Gemstone-2.4.x`     |                |
-| `Squeak-4.5`     | `Pharo-5.0`    |                      |                |
-|                  | `Pharo-4.0`    |                      |                |
-|                  | `Pharo-3.0`    |                      |                |
-|                  |                |                      |                |
+| [Squeak][squeak] | [Pharo][pharo] | [Pharo64][pharo64] | [GemStone][gemstone] | [Moose][moose] |
+| ---------------- | -------------- | ------------------ | -------------------- | -------------- |
+| `Squeak-trunk`   | `Pharo-alpha`  | `Pharo64-alpha`    | `GemStone-3.3.x`     | `Moose-trunk`  |
+| `Squeak-5.1`     | `Pharo-stable` | `Pharo64-alpha`    | `GemStone-3.2.x`     | `Moose-6.1`    |
+| `Squeak-5.0`     | `Pharo-7.0`    | `Pharo64-7.0`      | `GemStone-3.1.0.x`   | `Moose-6.0`    |
+| `Squeak-4.6`     | `Pharo-6.0`    | `Pharo64-6.0`      | `Gemstone-2.4.x`     |                |
+| `Squeak-4.5`     | `Pharo-5.0`    |                    |                      |                |
+|                  | `Pharo-4.0`    |                    |                      |                |
+|                  | `Pharo-3.0`    |                    |                      |                |
+|                  |                |                    |                      |                |
 
 
 ## <a name="templates"/>Templates
@@ -125,6 +125,11 @@ smalltalk:
   - Pharo-5.0
   - Pharo-4.0
   - Pharo-3.0
+
+  - Pharo64-alpha
+  - Pharo64-stable
+  - Pharo64-7.0
+  - Pharo64-6.0
 
   - GemStone-3.3.0
   - GemStone-3.2.12

--- a/pharo/run.sh
+++ b/pharo/run.sh
@@ -14,6 +14,18 @@ pharo::get_image_url() {
   local smalltalk_name=$1
 
   case "${smalltalk_name}" in
+    "Pharo64-alpha")
+      echo "get.pharo.org/64/alpha"
+      ;;
+    "Pharo64-stable")
+      echo "get.pharo.org/64/stable"
+      ;;
+    "Pharo64-7.0")
+      echo "get.pharo.org/64/70"
+      ;;
+    "Pharo64-6.0")
+      echo "get.pharo.org/64/60"
+      ;;
     "Pharo-alpha")
       echo "get.pharo.org/alpha"
       ;;
@@ -80,11 +92,17 @@ pharo::get_vm_url() {
 
   case "${smalltalk_name}" in
     # NOTE: vmLatestXX should be updated every time new Pharo is released
+    "Pharo64-alpha")
+      echo "get.pharo.org/64/vmLatest70"
+      ;;
+    "Pharo64-7.0")
+      echo "get.pharo.org/64/vm70"
+      ;;
+    "Pharo64-stable"|"Pharo64-6.0")
+      echo "get.pharo.org/64/vm60"
+      ;;
     "Pharo-alpha")
       echo "get.pharo.org/vmLatest70"
-      ;;
-    "Pharo-7.0")
-      echo "get.pharo.org/vm70"
       ;;
     "Pharo-7.0")
       echo "get.pharo.org/vm70"

--- a/run.sh
+++ b/run.sh
@@ -185,6 +185,7 @@ select_smalltalk() {
   local images="Squeak-trunk Squeak-5.1 Squeak-5.0 Squeak-4.6 Squeak-4.5
                 Pharo-stable Pharo-alpha Pharo-7.0 Pharo-6.0 Pharo-5.0 Pharo-4.0
                 Pharo-3.0
+                Pharo64-stable Pharo64-alpha Pharo64-7.0 Pharo64-6.0
                 GemStone-3.3.0 GemStone-3.2.12 GemStone-3.1.0.6
                 Moose-trunk Moose-6.1 Moose-6.0"
 


### PR DESCRIPTION
I added a support for Pharo 64 bit images/vms as requested in the issue #286

Now I think that maybe it makes more sense to have one more matrix axis fir 32/64 architectures? Squeak seems to be experimenting with 64 bit so probably they will release a stable version in a near future too. And Pharo 64 bit scripts mostly mirror the 32 bit ones