### PR TITLE
A better minimal .smalltalk.ston example

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,13 @@ SmalltalkCISpec {
   #loading : [
     SCIMetacelloLoadSpec {
       #baseline : 'MyProject',
-      #directory : 'packages',
+      #directory : './',
       #platforms : [ #squeak, #pharo, #gemstone ]
     }
   ]
+  #testing : {
+      #failOnZeroTests : false
+  }
 }
 ```
 


### PR DESCRIPTION
I think this is a more obvious minimal example - as not specifying any tests will automatically fail the build. The use of packages as a directory is also not the default that iceberg uses now - so ./ is more inline with what you get out of the box (you can leave it out, but this might be more obvious?)