### PR TITLE
Allow symlinking the main script

### DIFF
--- a/bin/smalltalkci
+++ b/bin/smalltalkci
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [[ -z "${SMALLTALK_CI_HOME:-}" || "$@" = *--self-test* ]]; then
-  readonly SMALLTALK_CI_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)"
+  readonly SMALLTALK_CI_HOME="$(cd "$(dirname "$(readlink "${BASH_SOURCE[0]}")")/../" && pwd)"
 fi
 
 "${SMALLTALK_CI_HOME}/run.sh" "$@"

--- a/bin/smalltalkci
+++ b/bin/smalltalkci
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
 if [[ -z "${SMALLTALK_CI_HOME:-}" || "$@" = *--self-test* ]]; then
-  readonly SMALLTALK_CI_HOME="$(cd "$(dirname "$(readlink "${BASH_SOURCE[0]}")")/../" && pwd)"
+  smalltalkci="${BASH_SOURCE[0]}" # start from this very file
+  [ -L "$smalltalkci" ] && smalltalkci="$(readlink "$smalltalkci")" # if it's a symlink, resolve it
+  smalltalkci="$( cd "$(dirname "$smalltalkci")" && pwd -P )" # resolve to physical path
+
+  readonly SMALLTALK_CI_HOME="$(dirname "$smalltalkci")"
 fi
 
 "${SMALLTALK_CI_HOME}/run.sh" "$@"


### PR DESCRIPTION
Since bin/smalltalkci tries to auto-detect the installation prefix from its own path, it
did not work through a symbolic link. Resolving the symlink as a first step fixes that.