### PR TITLE
failOnZeroTests mixup

### DIFF
--- a/repository/SmalltalkCI-Core.package/SCITestRunner.class/instance/tearDown.st
+++ b/repository/SmalltalkCI-Core.package/SCITestRunner.class/instance/tearDown.st
@@ -8,4 +8,4 @@ tearDown
 	(self spec failOnZeroTests and: [ self totalTests == 0 ])
 		ifTrue: [ SCIError signal: 'No tests were executed.
 
-If this is intended, use `#failOnZeroTests : true` in your SmalltalkCISpec.' ].
+If this is intended, use `#failOnZeroTests : false` in your SmalltalkCISpec.' ].


### PR DESCRIPTION
Besides the issue fixed in the commit there is another, maybe larger, one. When I ran a job with zero tests it initially failed which confused me as I always read the example configuration in the Readme.md as the standard configuration and so I was expecting the flag to be set to false and the build to not fail. Maybe we should add a sentence before the example configuration illustrating that these are merely some example values.