### PR TITLE
Update run.sh for GemStone

### DIFF
--- a/gemstone/run.sh
+++ b/gemstone/run.sh
@@ -204,7 +204,7 @@ gemstone::load_project() {
   local status=0
 
   fold_start load_server_project "Loading server project..."
-    travis_wait ${GS_HOME}/bin/startTopaz "${STONE_NAME}" -l -T 100000 << EOF || status=$?
+    travis_wait ${GS_HOME}/bin/startTopaz "${STONE_NAME}" -l -T ${GSCI_TOC:-100000} << EOF || status=$?
       iferr 1 stk
       iferr 2 stack
       iferr 3 exit 1
@@ -243,7 +243,7 @@ gemstone::test_project() {
   local status=0
   local failing_clients=()
 
-  travis_wait ${GS_HOME}/bin/startTopaz "${STONE_NAME}" -l -T 100000 << EOF || status=$?
+  travis_wait ${GS_HOME}/bin/startTopaz "${STONE_NAME}" -l -T ${GSCI_TOC:-100000} << EOF || status=$?
     iferr 1 stk
     iferr 2 stack
     iferr 3 exit 1


### PR DESCRIPTION
Partially fix:
https://github.com/hpi-swa/smalltalkCI/issues/396
In startTopaz command after -T option ${GSCI_TOC:-100000}
It will force TOC size to get value from env variable GSCI_TOC if not present then the default value is used (100000)

This commit does not fix --gs-TOC option of #396 (i think is a tODE option).