### PR TITLE
Adding Pharo9 as a valid version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,10 +64,12 @@ jobs:
     - smalltalk: Squeak32-5.0
     - smalltalk: Squeak32-4.6
     - smalltalk: Squeak32-4.5
+    - smalltalk: Pharo64-9.0
     - smalltalk: Pharo64-8.0
     - smalltalk: Pharo64-7.0
     - smalltalk: Pharo64-6.1
     - smalltalk: Pharo64-6.0
+    - smalltalk: Pharo32-9.0
     - smalltalk: Pharo32-8.0
     - smalltalk: Pharo32-7.0
     - smalltalk: Pharo32-6.0
@@ -96,6 +98,8 @@ jobs:
     - smalltalk: Squeak32-4.6
       os: osx
     - smalltalk: Squeak32-4.5
+      os: osx
+    - smalltalk: Pharo32-9.0
       os: osx
     - smalltalk: Pharo32-8.0
       os: osx

--- a/README.md
+++ b/README.md
@@ -73,19 +73,22 @@ they can take up a lot of space on your drive.*
 | ---------------- | ---------------- | -------------------- | --------------- |
 | `Squeak64-trunk` | `Pharo64-alpha`  | `GemStone64-3.5.x`   | `Moose64-trunk` |
 | `Squeak64-5.2`   | `Pharo64-stable` | `GemStone64-3.4.x`   | `Moose64-8.0`   |
-| `Squeak64-5.1`   | `Pharo64-8.0`    | `GemStone64-3.3.x`   | `Moose64-7.0`   |
-| `Squeak32-trunk` | `Pharo64-7.0`    | `GemStone64-3.2.x`   | `Moose32-trunk` |
-| `Squeak32-5.2`   | `Pharo64-6.1`    | `Gemstone64-3.1.0.x` | `Moose32-7.0`   |
-| `Squeak32-5.1`   | `Pharo64-6.0`    | `Gemstone64-2.4.x`   | `Moose32-6.1`   |
-| `Squeak32-5.0`   | `Pharo32-alpha`  |                      | `Moose32-6.0`   |
-| `Squeak32-4.6`   | `Pharo32-stable` |                      |                 |
-| `Squeak32-4.5`   | `Pharo32-8.0`    |                      |                 |
+| `Squeak64-5.1`   | `Pharo64-9.0`    | `GemStone64-3.3.x`   | `Moose64-7.0`   |
+| `Squeak32-trunk` | `Pharo64-8.0`    | `GemStone64-3.2.x`   | `Moose32-trunk` |
+| `Squeak32-5.2`   | `Pharo64-7.0`    | `Gemstone64-3.1.0.x` | `Moose32-7.0`   |
+| `Squeak32-5.1`   | `Pharo64-6.1`    | `Gemstone64-2.4.x`   | `Moose32-6.1`   |
+| `Squeak32-5.0`   | `Pharo64-6.0`    |                      | `Moose32-6.0`   |
+| `Squeak32-4.6`   | `Pharo32-alpha`  |                      |                 |
+| `Squeak32-4.5`   | `Pharo32-stable` |                      |                 |
+|                  | `Pharo32-9.0`    |                      |                 |
+|                  | `Pharo32-8.0`    |                      |                 |
 |                  | `Pharo32-7.0`    |                      |                 |
 |                  | `Pharo32-6.1`    |                      |                 |
 |                  | `Pharo32-6.0`    |                      |                 |
 |                  | `Pharo32-5.0`    |                      |                 |
 |                  | `Pharo32-4.0`    |                      |                 |
 |                  | `Pharo32-3.0`    |                      |                 |
+|                  |                  |                      |                 |
 
 
 ## <a name="templates"/>Templates

--- a/pharo/run.sh
+++ b/pharo/run.sh
@@ -122,12 +122,15 @@ pharo::get_vm_url() {
   case "${smalltalk_name}" in
     # NOTE: vmLatestXX should be updated every time new Pharo is released
     "Pharo64-alpha")
-      echo "get.pharo.org/64/vmLatest80"
+      echo "get.pharo.org/64/vmLatest90"
       ;;
-    "Pharo64-8.0"|"Moose64-8.0"|"Moose64-trunk")
+    "Pharo64-9.0")
+      echo "get.pharo.org/64/vm90"
+      ;;
+    "Pharo64-stable"|"Pharo64-8.0"|"Moose64-8.0"|"Moose64-trunk")
       echo "get.pharo.org/64/vm80"
       ;;
-    "Pharo64-stable"|"Pharo64-7.0"|"Moose64-7.0")
+    "Pharo64-7.0"|"Moose64-7.0")
       echo "get.pharo.org/64/vm70"
       ;;
     "Pharo64-6.1")
@@ -137,12 +140,15 @@ pharo::get_vm_url() {
       echo "get.pharo.org/64/vm60"
       ;;
     "Pharo32-alpha"|"Pharo-alpha")
-      echo "get.pharo.org/vmLatest80"
+      echo "get.pharo.org/vmLatest90"
       ;;
-    "Pharo32-8.0"|"Moose32-8.0"|"Moose32-trunk")
+    "Pharo32-9.0")
+      echo "get.pharo.org/vm90"
+      ;;
+    "Pharo-stable"|"Pharo32-stable"|"Pharo32-8.0"|"Moose32-8.0"|"Moose32-trunk")
       echo "get.pharo.org/vm80"
       ;;
-    "Pharo-stable"|"Pharo32-stable"|"Pharo32-7.0"|"Pharo-7.0"|"Moose32-7.0"|"Moose-7.0")
+    "Pharo32-7.0"|"Pharo-7.0"|"Moose32-7.0"|"Moose-7.0")
       echo "get.pharo.org/vm70"
       ;;
     "Pharo32-6.1"|"Moose32-6.1"|"Pharo-6.1"|"Moose-6.1")

--- a/pharo/run.sh
+++ b/pharo/run.sh
@@ -21,6 +21,9 @@ pharo::get_image_url() {
     "Pharo64-stable")
       echo "get.pharo.org/64/stable"
       ;;
+    "Pharo64-9.0")
+      echo "get.pharo.org/64/90"
+      ;;
     "Pharo64-8.0")
       echo "get.pharo.org/64/80"
       ;;
@@ -39,6 +42,9 @@ pharo::get_image_url() {
     "Pharo32-stable"|"Pharo-stable")
       echo "get.pharo.org/stable"
       ;;
+    "Pharo32-9.0")
+        echo "get.pharo.org/32/90"
+        ;;
     "Pharo32-8.0")
         echo "get.pharo.org/80"
         ;;

--- a/repository/BaselineOfSmalltalkCI.package/BaselineOfSmalltalkCI.class/instance/setUpPharo5AndGreaterPackages..st
+++ b/repository/BaselineOfSmalltalkCI.package/BaselineOfSmalltalkCI.class/instance/setUpPharo5AndGreaterPackages..st
@@ -2,7 +2,7 @@ baseline
 setUpPharo5AndGreaterPackages: spec
 
 	spec
-		for: #(#'pharo5.x' #'pharo6.x' #'pharo7.x' #'pharo8.x')
+		for: #(#'pharo5.x' #'pharo6.x' #'pharo7.x' #'pharo8.x' #'pharo9.x')
 		do: [ spec
 				package: 'SmalltalkCI-Core' with: [ spec includes: #('SmalltalkCI-Pharo-Core') ];
 				package: 'SmalltalkCI-Pharo-Core' with: [ spec requires: 'SmalltalkCI-Core' ];

--- a/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo78.class/class/isPlatformCompatible.st
+++ b/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo78.class/class/isPlatformCompatible.st
@@ -1,5 +1,5 @@
 compatibility
 isPlatformCompatible
-	^ (self platformNameBeginsWith: 'Pharo7')
-		or: [ self platformNameBeginsWith: 'Pharo8' ]
+	^ ((self platformNameBeginsWith: 'Pharo7')
+		or: [ self platformNameBeginsWith: 'Pharo8' ])
 		or: [ self platformNameBeginsWith: 'Pharo9' ]

--- a/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo78.class/class/isPlatformCompatible.st
+++ b/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo78.class/class/isPlatformCompatible.st
@@ -1,3 +1,5 @@
 compatibility
 isPlatformCompatible
-	^ (self platformNameBeginsWith: 'Pharo7') or: [ self platformNameBeginsWith: 'Pharo8' ]
+	^ (self platformNameBeginsWith: 'Pharo7')
+		or: [ self platformNameBeginsWith: 'Pharo8' ]
+		or: [ self platformNameBeginsWith: 'Pharo9' ]

--- a/run.sh
+++ b/run.sh
@@ -199,8 +199,8 @@ select_smalltalk() {
   local images="Squeak64-trunk Squeak64-5.2 Squeak64-5.1
                 Squeak32-trunk Squeak32-5.2 Squeak32-5.1 Squeak32-5.0
                 Squeak32-4.6 Squeak32-4.5
-                Pharo64-stable Pharo64-alpha Pharo64-8.0 Pharo64-7.0 Pharo64-6.1 Pharo64-6.0
-                Pharo32-stable Pharo32-alpha Pharo32-8.0 Pharo32-7.0 Pharo32-6.0 Pharo32-5.0
+                Pharo64-stable Pharo64-alpha Pharo64-9.0 Pharo64-8.0 Pharo64-7.0 Pharo64-6.1 Pharo64-6.0
+                Pharo32-stable Pharo32-alpha Pharo32-9.0 Pharo32-8.0 Pharo32-7.0 Pharo32-6.0 Pharo32-5.0
                 Pharo32-4.0 Pharo32-3.0
                 GemStone64-3.5.0 GemStone64-3.4.3 GemStone64-3.3.9
                 GemStone64-3.3.2 GemStone64-3.3.0 GemStone64-3.2.12

--- a/tests/pharo_tests.sh
+++ b/tests/pharo_tests.sh
@@ -16,6 +16,9 @@ test_get_image_url() {
   image_url="$(pharo::get_image_url "Pharo32-8.0")"
   assertEquals "get.pharo.org/80" "${image_url}"
 
+  image_url="$(pharo::get_image_url "Pharo64-9.0")"
+  assertEquals "get.pharo.org/64/90" "${image_url}"
+
   image_url="$(pharo::get_image_url "Pharo64-8.0")"
   assertEquals "get.pharo.org/64/80" "${image_url}"
 
@@ -48,10 +51,13 @@ test_get_vm_url() {
   local vm_url
 
   vm_url="$(pharo::get_vm_url "Pharo32-alpha")"
-  assertEquals "get.pharo.org/vmLatest80" "${vm_url}"
+  assertEquals "get.pharo.org/vmLatest90" "${vm_url}"
 
   vm_url="$(pharo::get_vm_url "Pharo32-stable")"
-  assertEquals "get.pharo.org/vm70" "${vm_url}"
+  assertEquals "get.pharo.org/vm80" "${vm_url}"
+
+  vm_url="$(pharo::get_vm_url "Pharo64-stable")"
+  assertEquals "get.pharo.org/64/vm80" "${vm_url}"
 
   vm_url="$(pharo::get_vm_url "Pharo32-8.0")"
   assertEquals "get.pharo.org/vm80" "${vm_url}"


### PR DESCRIPTION
We are getting ready to the release of Pharo8, and Pharo9 development has already started