### PR TITLE
Refine description of build metrics collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,10 +555,10 @@ EXAMPLE:
 ### Collection Of Anonymous Build Metrics
 
 smalltalkCI collects anonymous build metrics (Smalltalk dialect, CI environment,
-build status, build duration) for public repositories when running on a CI platform.
-This allows to identify build errors caused by smalltalkCI updates and
-therefore helps to improve the service. It is possible to opt-out by using the
-`--no-tracking` option.
+build status, build duration) for public repositories when running on a supported
+CI platform. This allows to identify build errors caused by smalltalkCI updates
+and therefore helps to improve the service. It is possible to opt-out by using
+the `--no-tracking` option.
 
 ### Travis-specific Options
 

--- a/README.md
+++ b/README.md
@@ -555,8 +555,7 @@ EXAMPLE:
 ### Collection Of Anonymous Build Metrics
 
 smalltalkCI collects anonymous build metrics (Smalltalk dialect, CI environment,
-build status, build duration) for public repositories when running on Travis CI
-or AppVeyor.
+build status, build duration) for public repositories when running on a CI platform.
 This allows to identify build errors caused by smalltalkCI updates and
 therefore helps to improve the service. It is possible to opt-out by using the
 `--no-tracking` option.


### PR DESCRIPTION
Build metrics are collected as well when running smalltalkCI another CI platform, e.g. GitHub Actions. Generalize the description so that no one can complain. :-)