### PR TITLE
Squeak: Specify exact Trunk image version

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -193,7 +193,27 @@ is_sudo_enabled() {
   $(sudo -n true > /dev/null 2>&1)
 }
 
+is_tagged_build() {
+  if [[ ([[:digit:]]+) =~ "${config_smalltalk}" ]]; then
+    export SCIII_SMALLTALK_VERSION="${BASH_REMATCH[1]}"
+    return 0
+  fi
+  return 1
+}
+
 is_trunk_build() {
+  if is_tagged_build; then
+    case "${config_smalltalk}" in
+      Squeak*)
+        SQ_LATEST_RELEASE="19431"
+        if [ "${SCIII_SMALLTALK_VERSION}" -ge "${SQ_LATEST_RELEASE}" ]; then
+          return 0
+        fi
+        ;;
+    esac
+    return 1
+  fi
+
   case "${config_smalltalk}" in
     *"trunk"|*"Trunk"|*"latest"|*"Latest")
       return 0

--- a/squeak/prepare.st
+++ b/squeak/prepare.st
@@ -1,4 +1,4 @@
-| monitor |
+| monitor trunk_version |
 FileStream startUp: true.
 monitor := [ [
   FileStream stdout nextPutAll: '.'.
@@ -37,19 +37,31 @@ Installer gemsource
 "=============================================================================="
 
 "Update Squeak image"
-Smalltalk at: #MCMcmUpdater ifPresent: [ :updater |
-  [[ (updater respondsTo: #doUpdate)
-    ifTrue: [ updater doUpdate ]
-    ifFalse: [
-      (updater respondsTo: #updateFromDefaultRepository)
-        ifTrue: [ updater updateFromDefaultRepository ]
-        ifFalse: [ ((updater respondsTo: #default) and: [
-          updater default respondsTo: #doUpdate: ])
-            ifTrue: [ updater default doUpdate: false ] ] ] ]
-    on: Warning do: [ :ex | ex resume: true ]]
+(SmalltalkCI getEnv: 'TRUNK_VERSION') ifNotNil: [ :version |
+  trunk_version = version asNumber].
+Smalltalk classNamed: #MCMcmUpdater ifPresent: [ :updater |
+  [ [ trunk_version
+    ifNotNil: [
+      updater defaultUpdateURL: MCHttpRepository trunkUrlString.
+      updater default doUpdate: false upTo: trunk_version ]
+    ifNil: [ (updater respondsTo: #doUpdate)
+      ifTrue: [ updater doUpdate ]
+      ifFalse: [
+        (updater respondsTo: #updateFromDefaultRepository)
+          ifTrue: [ updater updateFromDefaultRepository ]
+          ifFalse: [ ((updater respondsTo: #default) and: [
+            updater default respondsTo: #doUpdate: ])
+              ifTrue: [ updater default doUpdate: false ] ] ] ] ] ]
+    on: Warning do: [ :ex | ex resume: true ]
       on: Error do: [ :ex |
         FileStream stdout nextPutAll: ex asString.
-        Smalltalk snapshot: true andQuit: true ]].
+        Smalltalk snapshot: true andQuit: true ] ].
+trunk_version ifNotNil: [
+  self
+    assert: SystemVersion current highestUpdate = trunk_version
+    descriptionBlock: [ 'Should be Trunk version <1p> now but is <2p>'
+      expandMacrosWith: SystemVersion current highestUpdate
+      with: trunk_version ] ].
 
 monitor terminate.
 monitor := nil.

--- a/squeak/run.sh
+++ b/squeak/run.sh
@@ -122,9 +122,13 @@ squeak::prepare_image() {
   fold_start prepare_image "Preparing ${config_smalltalk} image for CI..."
     cp "${SMALLTALK_CI_HOME}/squeak/prepare.st" \
        "${SMALLTALK_CI_BUILD}/prepare.st"
+    if is_tagged_build; then
+      [[:alpha:]]+-([[:digit:]]+) =~ "${config_smalltalk}"
+      export TRUNK_VERSION="${BASH_REMATCH[1]}"
+    fi
     squeak::run_script "prepare.st" || status=$?
   fold_end prepare_image
-
+  
   if is_nonzero "${status}"; then
     print_error_and_exit "Failed to prepare image for CI." "${status}"
   fi
@@ -360,7 +364,7 @@ run_build() {
   if ! vm_is_user_provided; then
     squeak::prepare_vm
   fi
-  if is_trunk_build || image_is_user_provided; then
+  if is_tagged_build || is_trunk_build || image_is_user_provided; then
     squeak::prepare_image
   fi
   if ston_includes_loading; then


### PR DESCRIPTION
Trying to realize the idea I mentioned here: https://github.com/hpi-swa/smalltalkCI/issues/471#issuecomment-699024288

Usage: `smalltalkci -s "Squeak{{ 32 | 64}}-{{ version_number }}`, where `version_number` points to a Squeak version such as `19431`.

Work in progress, let's see whether it works ... :-)