### PR TITLE
TestSuite class should not be hard coded

### DIFF
--- a/repository/SmalltalkCI-Core.package/SCITestRunner.class/class/runClasses.spec..st
+++ b/repository/SmalltalkCI-Core.package/SCITestRunner.class/class/runClasses.spec..st
@@ -1,7 +1,7 @@
 running
 runClasses: aCollectionOfClasses spec: aSCISpec
   | suite classes |
-  suite := TestSuite named: aSCISpec name.
+  suite := aSCISpec suiteClass named: aSCISpec name.
   classes := (aCollectionOfClasses
     select: [ :each | (each includesBehavior: TestCase) and: [ each isAbstract not ] ])
       asSortedCollection: [ :a :b | a name <= b name ].

--- a/repository/SmalltalkCI-Core.package/SmalltalkCISpec.class/instance/suiteClass.st
+++ b/repository/SmalltalkCI-Core.package/SmalltalkCISpec.class/instance/suiteClass.st
@@ -1,0 +1,5 @@
+accessing
+suiteClass
+	^ suiteClass ifNil: [ suiteClass := self testing at: #'suiteClass'
+		ifPresent: [ :clazz |  (SmalltalkCI classesFrom: clazz) ]
+		ifAbsent: [ TestSuite ] ]

--- a/repository/SmalltalkCI-Core.package/SmalltalkCISpec.class/properties.json
+++ b/repository/SmalltalkCI-Core.package/SmalltalkCISpec.class/properties.json
@@ -15,7 +15,7 @@
 		"postTesting",
 		"name",
 		"specName",
-		"testSuite" ],
+		"suiteClass" ],
 	"name" : "SmalltalkCISpec",
 	"pools" : [
 		 ],

--- a/repository/SmalltalkCI-Core.package/SmalltalkCISpec.class/properties.json
+++ b/repository/SmalltalkCI-Core.package/SmalltalkCISpec.class/properties.json
@@ -14,7 +14,8 @@
 		"preTesting",
 		"postTesting",
 		"name",
-		"specName" ],
+		"specName",
+		"testSuite" ],
 	"name" : "SmalltalkCISpec",
 	"pools" : [
 		 ],


### PR DESCRIPTION
We should be able to run tests using a custom test suite class, that defines setup and teardown, run test in parallel, etc...

In my case, I'm doing e2e testing with Parasol (and Browserstack) of my Seaside webserver. My test cases could be run in parallel most of the time. The overall pipeline time could improve by a tone. And I could increase device coverage without increasing the time I spend executing in the pipeline.

I'm not sure about the contribution process, I tried using Pharo&Iceberg but the diff was all messed up... maybe due to tonel format...
So I had to redo the contribution using Github online edit... I'm not sure it works... But the idea is here. Please let me know about the contribution process, I'd be glad to redo the work. 