### PR TITLE
CLI: Fix --clean option if configuration is absent

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -9,6 +9,10 @@ readonly BINTRAY_API="https://api.bintray.com/content"
 readonly DEFAULT_STON_CONFIG="smalltalk.ston"
 readonly GITHUB_REPO_URL="https://github.com/hpi-swa/smalltalkCI"
 
+# Indicates whether any secondary action was chosen that makes the execution
+# of the actual build process optional. See ensure_ston_config_exists.
+first_action=""
+
 ################################################################################
 # Locate $SMALLTALK_CI_HOME and load helpers.
 ################################################################################
@@ -525,9 +529,6 @@ main() {
   local config_verbose="false"
   local config_vm=""
   local config_vm_dir
-  # Indicates whether any secondary action was chosen that makes the execution
-  # of the actual build process optional. See ensure_ston_config_exists.
-  local first_action=""
 
   initialize "$@"
   parse_options "$@"


### PR DESCRIPTION
`run.sh`: In `main()`, invert the invocation order of `check_clean_up` and 
`ensure_ston_config_exists`, to prevent error messages regarding the absence of configuration when the command was invoked to clean up the cache only. Resolve the existing dependency order which was manifested by the 
`config_smalltalk` variable (read in `check_clean_up` and written in `ensure_ston_config_exists`) by moving the "Continue with build progress?" prompt into the latter function, `ensure_ston_config_exists`. We only show this prompt if the local variable 
`first_action` has been set, which at the moment only happens in `check_clean_up`.

Fixes #519.