### PR TITLE
Updated appveyor.yaml example in README.md to use 64-bit Cygwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,11 +164,12 @@ smalltalk:
 ### `appveyor.yml` Template
 
 ```yml
+# This is a 64-bit environment, so use 64-bit Cygwin
 environment:
-  CYG_ROOT: C:\cygwin
-  CYG_BASH: C:\cygwin\bin\bash
-  CYG_CACHE: C:\cygwin\var\cache\setup
-  CYG_EXE: C:\cygwin\setup-x86.exe
+  CYG_ROOT: C:\cygwin64
+  CYG_BASH: C:\cygwin64\bin\bash
+  CYG_CACHE: C:\cygwin64\var\cache\setup
+  CYG_EXE: C:\cygwin64\setup-x86_64.exe
   CYG_MIRROR: http://cygwin.mirror.constant.com
   SCI_RUN: /cygdrive/c/smalltalkCI-master/bin/smalltalkci
   matrix:


### PR DESCRIPTION
My Fuel builds on AppVeyor have been failing because I was using the wrong architecture. I had not realized that Cygwin must be bootstrapped to 64-bits.

I have updated the appveyor.yaml example in the README.md to use 64-bit Cygwin, as the images in that example are 64-bit anyway.