### PR TITLE
feat: add support for Squeak 6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,12 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-2019 ]
         smalltalk:
           - Squeak64-trunk
+          - Squeak64-6.0
           - Squeak64-5.3
           - Squeak64-5.2
           - Squeak64-5.1
           - Squeak32-trunk
+          - Squeak32-6.0
           - Squeak32-4.5
           - Pharo64-stable
           - Pharo64-alpha
@@ -44,6 +46,8 @@ jobs:
         exclude: # exclude 32bit builds on macOS
           - os: macos-latest
             smalltalk: Squeak32-trunk
+          - os: macos-latest
+            smalltalk: Squeak32-6.0
           - os: macos-latest
             smalltalk: Squeak32-4.5
           - os: macos-latest

--- a/README.md
+++ b/README.md
@@ -72,18 +72,18 @@ they can take up a lot of space on your drive.*
 | [Squeak][squeak] | [Pharo][pharo]   | [GemStone][gemstone] | [Moose][moose]  |
 | ---------------- | ---------------- | -------------------- | --------------- |
 | `Squeak64-trunk` | `Pharo64-alpha`  | `GemStone64-3.5.x`   | `Moose64-trunk` |
-| `Squeak64-5.3`   | `Pharo64-stable` | `GemStone64-3.4.x`   | `Moose64-10`    | 
-| `Squeak64-5.2`   | `Pharo64-11`     | `GemStone64-3.3.x`   | `Moose64-9.0`   |
-| `Squeak64-5.1`   | `Pharo64-10`     | `GemStone64-3.2.x`   | `Moose64-8.0`   |
-| `Squeak64-trunk` | `Pharo64-9.0`    | `GemStone64-3.1.0.x` | `Moose64-7.0`   |
-| `Squeak32-5.3`   | `Pharo64-8.0`    | `Gemstone64-2.4.x`   | `Moose32-trunk` |
-| `Squeak32-5.2`   | `Pharo64-7.0`    |                      | `Moose32-6.1`   |
-| `Squeak32-5.1`   | `Pharo64-6.1`    |                      | `Moose32-6.0`   |
-| `Squeak32-5.0`   | `Pharo32-6.0`    |                      |                 |
-| `Squeak32-4.6`   | `Pharo32-alpha`  |                      |                 |
-| `Squeak32-4.5`   | `Pharo32-stable` |                      |                 |
-|                  | `Pharo32-11`     |                      |                 |
-|                  | `Pharo32-10`     |                      |                 |
+| `Squeak64-6.0`   | `Pharo64-stable` | `GemStone64-3.4.x`   | `Moose64-10`    | 
+| `Squeak64-5.3`   | `Pharo64-11`     | `GemStone64-3.3.x`   | `Moose64-9.0`   |
+| `Squeak64-5.2`   | `Pharo64-10`     | `GemStone64-3.2.x`   | `Moose64-8.0`   |
+| `Squeak64-5.1`   | `Pharo64-9.0`    | `GemStone64-3.1.0.x` | `Moose64-7.0`   |
+| `Squeak32-trunk` | `Pharo64-8.0`    | `Gemstone64-2.4.x`   | `Moose32-trunk` |
+| `Squeak32-6.0`   | `Pharo64-7.0`    |                      | `Moose32-6.1`   |
+| `Squeak32-5.3`   | `Pharo64-6.1`    |                      | `Moose32-6.0`   |
+| `Squeak32-5.2`   | `Pharo32-6.0`    |                      |                 |
+| `Squeak32-5.1`   | `Pharo32-alpha`  |                      |                 |
+| `Squeak32-5.0`   | `Pharo32-stable` |                      |                 |
+| `Squeak32-4.6`   | `Pharo32-11`     |                      |                 |
+| `Squeak32-4.5`   | `Pharo32-10`     |                      |                 |
 |                  | `Pharo32-9.0`    |                      |                 |
 |                  | `Pharo32-8.0`    |                      |                 |
 |                  | `Pharo32-7.0`    |                      |                 |

--- a/run.sh
+++ b/run.sh
@@ -220,8 +220,8 @@ in ${project_home}."
 #   config_smalltalk
 ################################################################################
 select_smalltalk() {
-  local images="Squeak64-trunk Squeak64-5.3 Squeak64-5.2 Squeak64-5.1
-                Squeak32-trunk Squeak32-5.3 Squeak32-5.2 Squeak32-5.1 Squeak32-5.0
+  local images="Squeak64-trunk Squeak64-6.0 Squeak64-5.3 Squeak64-5.2 Squeak64-5.1
+                Squeak32-trunk Squeak32-6.0 Squeak32-5.3 Squeak32-5.2 Squeak32-5.1 Squeak32-5.0
                 Squeak32-4.6 Squeak32-4.5
                 Pharo64-stable Pharo64-alpha Pharo64-11 Pharo64-10 Pharo64-9.0 Pharo64-8.0 Pharo64-7.0 Pharo64-6.1 Pharo64-6.0
                 Pharo32-stable Pharo32-alpha Pharo32-9.0 Pharo32-8.0 Pharo32-7.0 Pharo32-6.0 Pharo32-5.0

--- a/squeak/run.sh
+++ b/squeak/run.sh
@@ -14,6 +14,10 @@ squeak::download_image() {
   local git_tag
 
   case "${smalltalk_name}" in
+    "Squeak64-6.0")
+      download_name="Squeak64-6.0-19438.tar.gz" # FIXME: update once the archive exists
+      git_tag="v2.9.4"
+      ;;
     "Squeak64-5.3")
       download_name="Squeak64-5.3-19438.tar.gz"
       git_tag="v2.9.4"
@@ -24,6 +28,10 @@ squeak::download_image() {
       ;;
     "Squeak64-5.1")
       download_name="Squeak64-5.1-16555.tar.gz"
+      git_tag="v2.9.4"
+      ;;
+    "Squeak32-6.0")
+      download_name="Squeak32-6.0-19438.tar.gz"# FIXME: update once the archive exists
       git_tag="v2.9.4"
       ;;
     "Squeak32-5.3")
@@ -157,6 +165,10 @@ squeak::get_vm_details() {
     osvm_version="202206021410"
   else 
     case "${smalltalk_name}" in
+      "Squeak32-6.0 Squeak64-6.0")
+        git_tag="v2.9.9"
+        osvm_version="202206021410"
+        ;;
       "Squeak64-5.3")
         git_tag="v2.9.1"
         osvm_version="202003021730"


### PR DESCRIPTION
Add support for Squeak64-6.0 and Squeak32-6.0

IMPORTANT: needs to be updated with the prepared image names from the release before merging.

Fixes #556 