### PR TITLE
Add support for MSYS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,14 @@ or [download][download] smalltalkCI and then you are able to initiate a local
 build in headful mode like this:
 
 ```bash
-bin/smalltalkci --headful /path/to/your/project/.smalltalk.ston
+bin/smalltalkci -s <IMAGE> --headful /path/to/your/project/.smalltalk.ston
 ```
 
-`IMAGE` can be one of the [supported images](#images). You may also want to
+`<IMAGE>` can be one of the [supported images](#images). You may also want to
 have a look at [all supported options](#further-configuration).
+
+On Windows, you need to run smalltalkCI from a bash shell such as the
+[Git Bash](https://gitforwindows.org/) or Cygwin, MinGW, or MSYS2.
 
 *Please note: All builds will be stored in `_builds` within smalltalkCI's
 directory. You may want to delete single or all builds if you don't need them as

--- a/helpers.sh
+++ b/helpers.sh
@@ -189,6 +189,10 @@ is_mingw64_build() {
   [[ $(uname -s) = "MINGW64_NT-"* ]]
 }
 
+is_msys2_build() {
+  [[ $(uname -s) = "MSYS_NT-"* ]]
+}
+
 is_sudo_enabled() {
   $(sudo -n true > /dev/null 2>&1)
 }
@@ -358,7 +362,7 @@ extract_file() {
 resolve_path() {
   local path=$1
 
-  if is_cygwin_build || is_mingw64_build; then
+  if is_cygwin_build || is_mingw64_build || is_msys2_build; then
     echo $(cygpath -w "${path}")
   else
     echo "${path}"
@@ -398,7 +402,7 @@ ensure_jq_binary() {
         download_file "${JQ_BASE_URL}/jq-osx-amd64" "${jq_binary}"
         chmod +x "${jq_binary}"
         ;;
-      "CYGWIN_NT-"*|"MINGW64_NT-"*)
+      "CYGWIN_NT-"*|"MINGW64_NT-"*|"MSYS_NT-"*)
         download_file "${JQ_BASE_URL}/jq-win64.exe" "${jq_binary}"
         chmod +x "${jq_binary}"
         ;;

--- a/run.sh
+++ b/run.sh
@@ -21,7 +21,7 @@ initialize() {
 
   # Set up traps, otherwise fail if OS is not supported
   case "$(uname -s)" in
-    "Linux"|"Darwin"|"CYGWIN_NT-"*|"MINGW64_NT-"*)
+    "Linux"|"Darwin"|"CYGWIN_NT-"*|"MINGW64_NT-"*|"MSYS_NT-"*)
       trap handle_exit EXIT
       trap handle_error ERR
       trap handle_interrupt INT

--- a/squeak/run.sh
+++ b/squeak/run.sh
@@ -215,7 +215,7 @@ squeak::get_vm_details() {
       vm_file_ext="dmg"
       vm_path="${config_vm_dir}/Squeak.app/Contents/MacOS/Squeak"
       ;;
-    "CYGWIN_NT-"*|"MINGW64_NT-"*)
+    "CYGWIN_NT-"*|"MINGW64_NT-"*|"MSYS_NT-"*)
       if is_64bit; then
         vm_arch="win64x64"
       else


### PR DESCRIPTION
Similar to cygwin and mingw, MSYS allows Windows users to run linux commands. Amongst others, MSYS2 via MinTTY is promoted by the Git Bash.

Also updates the README section on how to build locally.