### PR TITLE
Equate travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,8 @@ the `--no-tracking` option.
 
 ### Travis-specific Options
 
+#### Travis Timeouts
+
 Jobs on Travis CI [timeout if they don't produce output for
 more than 10 minutes][travisTimeout]. In case of long running tests, it
 is possible to increase this timeout by setting `$SMALLTALK_CI_TIMEOUT` in your
@@ -588,7 +590,7 @@ env:
 The above sets the timeout to 30 minutes. Please note that Travis CI enforces
 [a total build timeout of 50 minutes][travisTimeout].
 
-### Using A Different smalltalkCI Branch Or Fork
+#### Using A Different smalltalkCI Branch Or Fork
 
 By default, the smalltalkCI master branch is used to perform a build. It is
 possible to select a different smalltalkCI branch or fork for testing/debugging

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ debugging purposes or when used locally:
 ```
 USAGE: bin/smalltalkci [options] /path/to/project/your_smalltalk.ston
 
-This program prepares Smalltalk images/vms, loads projects and runs tests.
+This program prepares Smalltalk images/vms, loads projects, and runs tests.
 
 OPTIONS:
   --clean             Clear cache and delete builds.
@@ -554,6 +554,7 @@ OPTIONS:
   --image             Custom image for build (Squeak/Pharo).
   --install           Install symlink to this smalltalkCI instance.
   --print-env         Print all environment variables used by smalltalkCI
+  --no-color          Disable colored output
   --no-tracking       Disable collection of anonymous build metrics (Travis CI & AppVeyor only).
   -s | --smalltalk    Overwrite Smalltalk image selection.
   --uninstall         Remove symlink to any smalltalkCI instance.
@@ -561,7 +562,7 @@ OPTIONS:
   --vm                Custom VM for build (Squeak/Pharo).
 
 EXAMPLE:
-  bin/smalltalkci -s "Squeak-trunk" --headful /path/to/project/.smalltalk.ston
+  bin/smalltalkci -s "Squeak64-trunk" --headfull /path/to/project/.smalltalk.ston
 ```
 
 ### Collection Of Anonymous Build Metrics

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ way to load and test Smalltalk projects.
 ## Table Of Contents
 
 - [Features](#features)
-- [How to enable Travis CI for your Smalltalk project](#how-to-travis)
+- [How to enable Continuous Integration for your Smalltalk project](#how-to-ci)
 - [How to test your Smalltalk project locally](#how-to-local)
 - [List Of Supported Images](#images)
 - [Templates](#templates)
@@ -37,16 +37,14 @@ way to load and test Smalltalk projects.
 - Exports test results in the JUnit XML format as part of the build log
 
 
-## <a name="how-to-travis"/>How To Enable Travis CI For Your Smalltalk Project
+## <a name="how-to-ci"/>How To Enable Continuous Integration For Your Smalltalk Project
 
 1. Export your project in a [compatible format](#load-specs) (e.g.
    [FileTree][filetree]).
-2. [Enable Travis CI for your repository][travisHowTo].
-3. Create a `.travis.yml` and specifiy the [Smalltalk image(s)](#images) you
-   want your project to be tested against.
-4. Create a `.smalltalk.ston` ([see below for templates](#templates)) and
-   specify how to load and test your project.
-5. Push all of this to GitHub and enjoy your fast Smalltalk builds!
+2. Enable a CI service for your repository (e.g., [GitHub Actions][github_actions], [Travis CI][travisHowTo], autc.).
+3. Create a config file for your CI service ([see below for templates](#templates)) and specify the [Smalltalk image(s)](#images) you want your project to be tested against.
+4. Create a [`.smalltalk.ston` file](#minimal-.smalltalk-.ston) and specify how to load and test your project.
+5. Push all of this to your repository and enjoy your fast Smalltalk builds!
 
 
 ## <a name="how-to-local"/>How To Test Your Smalltalk Project Locally
@@ -95,9 +93,9 @@ they can take up a lot of space on your drive.*
 |                  |                  |                      |                 |
 
 
-## <a name="templates"/>Templates
+## Templates
 
-### Minimal `.smalltalk.ston` Template
+### <a name="minimal-.smalltalk.ston"/>Minimal `.smalltalk.ston` Template
 
 The following `SmalltalkCISpec` will load `BaselineOfMyProject` using
 Metacello/FileTree from the `./packages` directory in Squeak, Pharo, and
@@ -722,6 +720,7 @@ list. Please add [`[ci skip]`][ci_skip] to your commit message.*
 [github_action]: https://github.com/marketplace/actions/setup-smalltalkci
 [github_action_b]: https://img.shields.io/github/workflow/status/hpi-swa/smalltalkCI/smalltalkCI%20Self%20Test?logo=github
 [github_action_url]: https://github.com/hpi-swa/smalltalkCI/actions
+[github_actions]: https://github.com/features/actions
 [gitlab_ci_cd]: https://about.gitlab.com/features/gitlab-ci-cd/
 [gofer]: http://www.lukas-renggli.ch/blog/gofer
 [gs]: https://github.com/hpi-swa/smalltalkCI/issues/28

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ way to load and test Smalltalk projects.
    [FileTree][filetree]).
 2. Enable a CI service for your repository (e.g., [GitHub Actions][github_actions], [Travis CI][travisHowTo], autc.).
 3. Create a config file for your CI service ([see below for templates](#templates)) and specify the [Smalltalk image(s)](#images) you want your project to be tested against.
-4. Create a [`.smalltalk.ston` file](#minimal-.smalltalk-.ston) and specify how to load and test your project.
+4. Create a [`.smalltalk.ston` file](#minimal-smalltalkston-template) and specify how to load and test your project.
 5. Push all of this to your repository and enjoy your fast Smalltalk builds!
 
 
@@ -97,7 +97,7 @@ they can take up a lot of space on your drive.*
 
 ## Templates
 
-### <a name="minimal-.smalltalk.ston"/>Minimal `.smalltalk.ston` Template
+### <a name="minimal-smalltalkston-template"/>Minimal `.smalltalk.ston` Template
 
 The following `SmalltalkCISpec` will load `BaselineOfMyProject` using
 Metacello/FileTree from the `./packages` directory in Squeak, Pharo, and

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# smalltalkCI [![GitHub Workflow Status][github_action_b]][github_action_url] [![Travis CI Status][travis_b]][travis_url] [![AppVeyor Status][appveyor_b]][appveyor_url] [![Docker Build Status][docker_b]][docker_url] [![Coverage Status][coveralls_b]][coveralls_url]
+# smalltalkCI
+
+[![GitHub Workflow Status][github_action_b]][github_action_url] [![Travis CI Status][travis_b]][travis_url] [![AppVeyor Status][appveyor_b]][appveyor_url] [![Docker Build Status][docker_b]][docker_url] [![Coverage Status][coveralls_b]][coveralls_url]
 
 Community-supported framework for testing Smalltalk projects on Linux, OS X, and
 Windows with built-in support for [GitHub Actions][github_action],
@@ -119,7 +121,7 @@ For GitHub Action templates, please refer to the Marketplace listing of the
 [`setup-smalltalkCI` action][github_action].
 
 
-### `.travis.yml` Template
+### <a name="travisyml-template"/>Travis CI Template (`.travis.yml`)
 
 ```yml
 language: smalltalk
@@ -163,7 +165,7 @@ smalltalk:
 
 ```
 
-### `appveyor.yml` Template
+### <a name="appveyoryml-template"/>AppVeyor Template (`appveyor.yml`)
 
 ```yml
 # This is a 64-bit environment, so use 64-bit Cygwin
@@ -219,7 +221,7 @@ Pharo327.0:
 ### Advanced Templates
 
 <details>
-<summary>`.travis.yml` template with multiple smalltalkCI configurations</summary>
+<summary><code>.travis.yml</code> template with multiple smalltalkCI configurations</summary>
 
 The build matrix can be expanded with multiple smalltalkCI configuration files
 using the `smalltalk_config` key:
@@ -264,7 +266,7 @@ SmalltalkCISpec {
 </details>
 
 <details>
-<summary>`.travis.yml` template with additional jobs</summary>
+<summary><code>.travis.yml</code> template with additional jobs</summary>
 
 It is possible to add additional jobs to the [build matrix][build_matrix_travis]
 using the `smalltalk_config` key:
@@ -301,7 +303,7 @@ matrix:
 </details>
 
 <details>
-  <summary>`appveyor.yml` template with additional jobs</summary>
+  <summary><code>appveyor.yml</code> template with additional jobs</summary>
 
 It is possible to add additional jobs to the
 [build matrix][build_matrix_appveyor] using `environment.matrix` as follows:

--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -33,7 +33,7 @@ The `#coverage` dictionary can contain the following options:
   - The output format of the Coverage data 
   - May be either `#coveralls` or `#lcov`
 
-When running smalltalkCI on TravisCI or AppVeyor with the `#coveralls` coverage format, the results will be uploaded to [Coveralls][coveralls] automatically.
+When running smalltalkCI on Travis CI or AppVeyor with the `#coveralls` coverage format, the results will be uploaded to [Coveralls][coveralls] automatically.
 Make sure your repository is [added to Coveralls][coveralls_new].
 
 ## Uploading with different CI-services/Coverage reporters
@@ -54,7 +54,7 @@ For the most common usecases, see these instructions:
   - [Travis CI](#coveralls-%26-travis-ci)
   - [GitHub actions](#coveralls-%26-github-actions)
 - [CodeCov](#codecov)
-  - [Travis CI](#codecov-%26-travisci)
+  - [Travis CI](#codecov-%26-travis-ci)
   - [GitHub actions](#codecov-%26-github-actions)
 - [Cobertura](#cobertura)
   - [GitLab CI](#cobertura-%26-gitlabci)
@@ -150,7 +150,7 @@ Generally it will be:
 bash <(curl -s https://codecov.io/bash)
 ```
 
-#### CodeCov & TravisCI
+#### CodeCov & Travis CI
 Add this to your `.travis.yml`
 ```yml
 after_success:

--- a/gemstone/README.md
+++ b/gemstone/README.md
@@ -110,7 +110,7 @@ The things to note about the `.travis.yml` are:
 
 1. I'm only running one OSX build for GemStone 3.3.0. There are fewer OSX servers currently available on Travis, so you end up waiting longer for a server to become available - sometimes all of the linux builds finish before an osx server becomes available. A second reason is that dependency caching (see point 2 below) is not available on OSX and that can make a big difference in build times:
   - [a recent tODE build](https://travis-ci.org/dalehenrich/tode/builds/121809026) took as low as 13 minutes on linux is load dep (with dependency caching) and 27 minutes on OSX (with no dependency caching). 
-2. I'm taking advantage of [Travis Depdendency Caching](https://docs.travis-ci.com/user/caching/). Two things are cached for GemStone builds:
+2. I'm taking advantage of [Travis Dependency Caching](https://docs.travis-ci.com/user/caching/). Two things are cached for GemStone builds:
    - an extent0.tode.dbf file for each GemStone version.
    - the devKitCommandLine image
    The extent is the big winner, saving 2/3 of the time over non-cached build. The extent is cached immediately after the end of a `$GS_HOME/bin/createStone` ends. The devKitCommandLine image is cached to save on the download times for the Pharo image and vm.

--- a/gemstone/run.sh
+++ b/gemstone/run.sh
@@ -1,7 +1,7 @@
 ################################################################################
 # This file provides GemStone support for smalltalkCI. It is used in the context
 # of a smalltalkCI build and it is not meant to be executed by itself.
-################################################################################ 
+################################################################################
 
 local CLIENT_NAME="travisClient"
 local DEFAULT_DEVKIT_BRANCH="master"
@@ -66,7 +66,7 @@ gemstone::prepare_stone() {
   fi
 
   if ! is_dir "${SMALLTALK_CI_CACHE}/gemstone"; then
-    print_info "Creating GemStone extent cache..." 
+    print_info "Creating GemStone extent cache..."
     mkdir "${SMALLTALK_CI_CACHE}/gemstone"
     if ! is_dir "${SMALLTALK_CI_CACHE}/gemstone/extents"; then
       mkdir "${SMALLTALK_CI_CACHE}/gemstone/extents"
@@ -83,15 +83,15 @@ gemstone::prepare_stone() {
     fold_start prepare_cache "Preparing Travis caches..."
       if ! is_dir "${SMALLTALK_CI_VMS}/Pharo-3.0"; then
         mkdir -p "${SMALLTALK_CI_VMS}/Pharo-3.0"
-        print_info "Downloading Pharo-3.0 vm to cache" 
+        print_info "Downloading Pharo-3.0 vm to cache"
         pushd "${SMALLTALK_CI_VMS}/Pharo-3.0" > /dev/null
           download_file "get.pharo.org/vm30" "$(pwd)/zeroconfig"
           bash "$(pwd)/zeroconfig"
         popd > /dev/null
       fi
-  
+
       if ! is_file "${SMALLTALK_CI_CACHE}/${PHARO_IMAGE_FILE}"; then
-        print_info "Downloading Pharo-3.0 image to cache..." 
+        print_info "Downloading Pharo-3.0 image to cache..."
         pushd ${SMALLTALK_CI_CACHE} > /dev/null
           download_file "get.pharo.org/30" "$(pwd)/pharo30_zeroconfig"
           bash "$(pwd)/pharo30_zeroconfig"
@@ -99,10 +99,10 @@ gemstone::prepare_stone() {
           mv "Pharo.changes" "${PHARO_CHANGES_FILE}"
         popd > /dev/null
       fi
-  
+
       if is_file "${SMALLTALK_CI_CACHE}/${PHARO_IMAGE_FILE}"; then
         if is_file "${SMALLTALK_CI_CACHE}/gemstone/pharo/gsDevKitCommandLine.image"; then
-          print_info "Utilizing cached gsDevKitCommandLine image..." 
+          print_info "Utilizing cached gsDevKitCommandLine image..."
           cp "${SMALLTALK_CI_CACHE}/${PHARO_IMAGE_FILE}" ${GS_HOME}/shared/pharo/Pharo.image
           cp "${SMALLTALK_CI_CACHE}/${PHARO_CHANGES_FILE}" ${GS_HOME}/shared/pharo/Pharo.changes
           ln -s "${SMALLTALK_CI_VMS}/Pharo-3.0/pharo" ${GS_HOME}/shared/pharo/pharo
@@ -129,7 +129,7 @@ gemstone::prepare_stone() {
       else
         ${GS_HOME}/bin/createStone -t "${gemstone_cached_extent_file}" ${config_stone_create_arg:-} "${STONE_NAME}" "${gemstone_version}"
       fi
-  
+
       if ! is_file "${SMALLTALK_CI_CACHE}/gemstone/pharo/gsDevKitCommandLine.image"; then
         cp ${GS_HOME}/shared/pharo/gsDevKitCommandLine.* "${SMALLTALK_CI_CACHE}/gemstone/pharo/"
       fi
@@ -206,7 +206,7 @@ gemstone::load_project() {
   local status=0
 
   fold_start load_server_project "Loading server project..."
-    travis_wait ${GS_HOME}/bin/startTopaz "${STONE_NAME}" -l -T ${GSCI_TOC:-100000} << EOF || status=$?
+    run_script ${GS_HOME}/bin/startTopaz "${STONE_NAME}" -l -T ${GSCI_TOC:-100000} << EOF || status=$?
       iferr 1 stk
       iferr 2 stack
       iferr 3 exit 1
@@ -245,7 +245,7 @@ gemstone::test_project() {
   local status=0
   local failing_clients=()
 
-  travis_wait ${GS_HOME}/bin/startTopaz "${STONE_NAME}" -l -T ${GSCI_TOC:-100000} << EOF || status=$?
+  run_script ${GS_HOME}/bin/startTopaz "${STONE_NAME}" -l -T ${GSCI_TOC:-100000} << EOF || status=$?
     iferr 1 stk
     iferr 2 stack
     iferr 3 exit 1
@@ -265,7 +265,7 @@ EOF
   if is_not_empty  "${DEVKIT_CLIENT_NAMES:-}"; then
     for client_name in "${DEVKIT_CLIENT_NAMES[@]}"
     do
-      travis_wait ${GS_HOME}/bin/startClient ${client_name} -t "${client_name}" -s ${STONE_NAME} -z "${config_ston}" || status=$?
+      run_script ${GS_HOME}/bin/startClient ${client_name} -t "${client_name}" -s ${STONE_NAME} -z "${config_ston}" || status=$?
 
       if is_nonzero "${status}"; then
         print_error_and_exit "Error while testing client project ${client_name}."

--- a/helpers.sh
+++ b/helpers.sh
@@ -71,7 +71,7 @@ print_help() {
     --install           Install symlink to this smalltalkCI instance.
     --print-env         Print all environment variables used by smalltalkCI
     --no-color          Disable colored output
-    --no-tracking       Disable collection of anonymous build metrics (TravisCI & AppVeyor only).
+    --no-tracking       Disable collection of anonymous build metrics (Travis CI & AppVeyor only).
     -s | --smalltalk    Overwrite Smalltalk image selection.
     --uninstall         Remove symlink to any smalltalkCI instance.
     -v | --verbose      Enable 'set -x'.
@@ -644,7 +644,7 @@ timer_nanoseconds() {
   $cmd -u $format
 }
 
-travis_wait() {
+run_script() {
   local timeout="${SMALLTALK_CI_TIMEOUT:-}"
 
   local cmd="$@"
@@ -654,6 +654,7 @@ travis_wait() {
     return $?
   fi
 
+  # simulate activity for Travis CI
   $cmd &
   local cmd_pid=$!
 
@@ -675,7 +676,7 @@ travis_wait() {
 }
 
 travis_jigger() {
-  # helper method for travis_wait()
+  # helper method for run_script()
   local cmd_pid=$1
   shift
   local timeout=$1 # in minutes
@@ -699,11 +700,12 @@ travis_jigger() {
 fold_start() {
   local identifier=$1
   local title=$2
-  local prefix="${SMALLTALK_CI_TRAVIS_FOLD_PREFIX:-}"
 
   timer_start_time=$(timer_nanoseconds)
-  travis_timer_id=$(printf %08x $(( RANDOM * RANDOM )))
+
   if is_travis_build; then
+    local prefix="${SMALLTALK_CI_TRAVIS_FOLD_PREFIX:-}"
+    travis_timer_id=$(printf %08x $(( RANDOM * RANDOM )))
     echo -en "travis_fold:start:${prefix}${identifier}\r${ANSI_CLEAR}"
     echo -en "travis_time:start:$travis_timer_id\r${ANSI_CLEAR}"
   fi
@@ -716,11 +718,12 @@ fold_start() {
 
 fold_end() {
   local identifier=$1
-  local prefix="${SMALLTALK_CI_TRAVIS_FOLD_PREFIX:-}"
+
   local timer_end_time=$(timer_nanoseconds)
   local duration=$(($timer_end_time-$timer_start_time))
 
   if is_travis_build; then
+    local prefix="${SMALLTALK_CI_TRAVIS_FOLD_PREFIX:-}"
     echo -en "travis_time:end:$travis_timer_id:start=$timer_start_time,finish=$timer_end_time,duration=$duration\r${ANSI_CLEAR}"
     echo -en "travis_fold:end:${prefix}${identifier}\r${ANSI_CLEAR}"
   else

--- a/pharo/run.sh
+++ b/pharo/run.sh
@@ -327,7 +327,7 @@ pharo::run_script() {
     vm_flags="--no-quit"
   fi
 
-  travis_wait "${resolved_vm}" "${resolved_image}" --no-default-preferences eval ${vm_flags} "${script}"
+  run_script "${resolved_vm}" "${resolved_image}" --no-default-preferences eval ${vm_flags} "${script}"
 }
 
 ################################################################################

--- a/squeak/run.sh
+++ b/squeak/run.sh
@@ -83,7 +83,7 @@ squeak::download_prepared_image() {
   print_info "Extracting image..."
   extract_file "${target}" "${SMALLTALK_CI_BUILD}"
   # TODO: cleanup soon, some archives still include TravisCI.(image|changes)
-  if ! is_file "${SMALLTALK_CI_IMAGE}"; then 
+  if ! is_file "${SMALLTALK_CI_IMAGE}"; then
     mv "${SMALLTALK_CI_BUILD}"/*.image "${SMALLTALK_CI_IMAGE}"
     mv "${SMALLTALK_CI_BUILD}"/*.changes "${SMALLTALK_CI_CHANGES}"
   fi
@@ -126,7 +126,7 @@ squeak::download_trunk_image() {
 ################################################################################
 squeak::prepare_image() {
   local status=0
-  
+
   fold_start prepare_image "Preparing ${config_smalltalk} image for CI..."
     cp "${SMALLTALK_CI_HOME}/squeak/prepare.st" \
        "${SMALLTALK_CI_BUILD}/prepare.st"
@@ -164,7 +164,7 @@ squeak::get_vm_details() {
   if is_trunk_build; then
     git_tag="v2.9.9"
     osvm_version="202206021410"
-  else 
+  else
     case "${smalltalk_name}" in
       "Squeak32-6.0"|"Squeak64-6.0")
         git_tag="v2.9.9"
@@ -317,7 +317,7 @@ squeak::run_script() {
       ;;
   esac
 
-  travis_wait "${resolved_vm}" ${vm_flags} "${resolved_image}" "${script}"
+  run_script "${resolved_vm}" ${vm_flags} "${resolved_image}" "${script}"
 }
 
 ################################################################################


### PR DESCRIPTION
Update docs and vocabulary to avoid overemphasizing Travis CI over other CI providers. Also includes some minor other fixes to the docs and styling.