### PR TITLE
Fix bug in ‘pharo::prepare_image’ which always downloads the image again

### DIFF
--- a/pharo/run.sh
+++ b/pharo/run.sh
@@ -270,8 +270,8 @@ pharo::prepare_image() {
   local target="${SMALLTALK_CI_CACHE}/${smalltalk_name}"
   local pharo_zeroconf="${target}/zeroconfig"
 
-  if ! is_file "${target}"; then
-    is_dir "${target}" || mkdir "${target}"
+  if ! is_dir "${target}"; then
+    mkdir "${target}"
     pushd "${target}" > /dev/null
     fold_start download_image "Downloading ${smalltalk_name} image..."
       download_file "${pharo_image_url}" "${pharo_zeroconf}"


### PR DESCRIPTION
This pull request fixes a bug in ‘pharo::prepare_image’ where the image was always downloaded again due to ‘is_file’ being used instead of ‘is_dir’ to test the existence of the ‘target’ directory.

The bug seems to have been introduced in commit 3018a631f2a5839d, [the test](https://github.com/hpi-swa/smalltalkCI/commit/3018a631f2a5839dbb465df7ceebd5b32c1c384b#diff-7f52e0a9b563ce4153613b54b061993866eae81210e41e93a4c81362d31f29b7L189-R187) previously checked the existence of the image file instead of the directory.