### PR TITLE
feat: update Pharo VM and image urls

### DIFF
--- a/pharo/run.sh
+++ b/pharo/run.sh
@@ -15,10 +15,10 @@ pharo::get_image_url() {
   local smalltalk_name=$1
 
   case "${smalltalk_name}" in
-    "Pharo64-alpha")
+    "Pharo64-alpha"|"Pharo-alpha")
       echo "get.pharo.org/64/alpha"
       ;;
-    "Pharo64-stable")
+    "Pharo64-stable"|"Pharo-stable")
       echo "get.pharo.org/64/stable"
       ;;
     "Pharo64-12")
@@ -45,12 +45,15 @@ pharo::get_image_url() {
     "Pharo64-6.0")
       echo "get.pharo.org/64/60"
       ;;
-    "Pharo32-alpha"|"Pharo-alpha")
+    "Pharo32-alpha")
       echo "get.pharo.org/alpha"
       ;;
-    "Pharo32-stable"|"Pharo-stable")
+    "Pharo32-stable")
       echo "get.pharo.org/stable"
       ;;
+    "Pharo32-12")
+        echo "get.pharo.org/32/120"
+        ;;
     "Pharo32-11")
         echo "get.pharo.org/32/110"
         ;;
@@ -142,14 +145,16 @@ moose::get_image_url() {
 ################################################################################
 pharo::get_vm_url() {
   local smalltalk_name=$1
+  local stable_version=11
+  local alpha_version=12
 
   case "${smalltalk_name}" in
     # NOTE: vmLatestXX should be updated every time new Pharo is released
-    "Pharo64-alpha")
-      echo "get.pharo.org/64/vmLatest110"
+    "Pharo64-alpha"|"Pharo-alpha")
+      echo "get.pharo.org/64/vmLatest${alpha_version}0"
       ;;
-    "Pharo64-stable")
-      echo "get.pharo.org/64/vm100"
+    "Pharo64-stable"|"Pharo-stable")
+      echo "get.pharo.org/64/vm${stable_version}0"
       ;;
     "Pharo64-12")
       echo "get.pharo.org/64/vm120"
@@ -175,11 +180,14 @@ pharo::get_vm_url() {
     "Pharo64-6.0")
       echo "get.pharo.org/64/vm60"
       ;;
-    "Pharo32-alpha"|"Pharo-alpha")
-      echo "get.pharo.org/vmLatest110"
+    "Pharo32-alpha")
+      echo "get.pharo.org/vmLatest${alpha_version}0"
       ;;
-    "Pharo-stable"|"Pharo32-stable")
-      echo "get.pharo.org/vm100"
+    "Pharo32-stable")
+      echo "get.pharo.org/vm${stable_version}0"
+      ;;
+    "Pharo32-12")
+      echo "get.pharo.org/vm120"
       ;;
     "Pharo32-11")
       echo "get.pharo.org/vm110"

--- a/tests/pharo_tests.sh
+++ b/tests/pharo_tests.sh
@@ -13,6 +13,15 @@ test_get_image_url() {
   image_url="$(pharo::get_image_url "Pharo32-stable")"
   assertEquals "get.pharo.org/stable" "${image_url}"
 
+  image_url="$(pharo::get_image_url "Pharo64-alpha")"
+  assertEquals "get.pharo.org/64/alpha" "${image_url}"
+
+  image_url="$(pharo::get_image_url "Pharo64-stable")"
+  assertEquals "get.pharo.org/64/stable" "${image_url}"
+
+  image_url="$(pharo::get_image_url "Pharo64-12")"
+  assertEquals "get.pharo.org/64/120" "${image_url}"
+
   image_url="$(pharo::get_image_url "Pharo64-11")"
   assertEquals "get.pharo.org/64/110" "${image_url}"
 
@@ -54,16 +63,19 @@ test_get_vm_url() {
   local vm_url
 
   vm_url="$(pharo::get_vm_url "Pharo32-alpha")"
-  assertEquals "get.pharo.org/vmLatest110" "${vm_url}"
+  assertEquals "get.pharo.org/vmLatest120" "${vm_url}"
 
   vm_url="$(pharo::get_vm_url "Pharo64-alpha")"
-  assertEquals "get.pharo.org/64/vmLatest110" "${vm_url}"
+  assertEquals "get.pharo.org/64/vmLatest120" "${vm_url}"
 
   vm_url="$(pharo::get_vm_url "Pharo32-stable")"
-  assertEquals "get.pharo.org/vm100" "${vm_url}"
+  assertEquals "get.pharo.org/vm110" "${vm_url}"
 
   vm_url="$(pharo::get_vm_url "Pharo64-stable")"
-  assertEquals "get.pharo.org/64/vm100" "${vm_url}"
+  assertEquals "get.pharo.org/64/vm110" "${vm_url}"
+
+  vm_url="$(pharo::get_vm_url "Pharo32-12")"
+  assertEquals "get.pharo.org/vm120" "${vm_url}"
 
   vm_url="$(pharo::get_vm_url "Pharo32-11")"
   assertEquals "get.pharo.org/vm110" "${vm_url}"


### PR DESCRIPTION
Note: This commit also changes `Pharo-stable` and `Pharo-alpha` to be synonyms of `Pharo64-stable` and `Pharo64-alpha`, respectively. Previously, these aliases referred to the 32-bit versions.