### PR TITLE
Updates for Pharo12 deprecated methods.

### DIFF
--- a/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo12.class/class/allCategoryNames.st
+++ b/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo12.class/class/allCategoryNames.st
@@ -7,5 +7,5 @@ allCategoryNames
 		streamContents: [ :stream |
 			packages do: [ :package |
 				stream nextPut: package name asString.
-				package classTags do: [ :tag |
+				package tags do: [ :tag |
 					stream nextPut: tag categoryName asString ] ] ]) asSet asArray

--- a/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo12.class/class/setAuthor..st
+++ b/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo12.class/class/setAuthor..st
@@ -1,0 +1,3 @@
+helpers
+setAuthor: anAuthor
+	(Smalltalk at: #Author) fullName: anAuthor

--- a/repository/SmalltalkCI-Tests.package/SmalltalkCITest.class/instance/testAuthor.st
+++ b/repository/SmalltalkCI-Tests.package/SmalltalkCITest.class/instance/testAuthor.st
@@ -1,11 +1,11 @@
 testing
 testAuthor
 	| currentAuthor |
-	currentAuthor := SmalltalkCI getAuthor.
+	currentAuthor := SmalltalkCI platformClass getAuthor.
 	
 	[
-	SmalltalkCI basicNew initialize.
-	self deny: SmalltalkCI defaultAuthor isNil.
+	SmalltalkCI platformClass: nil.
+	self deny: SmalltalkCI platformClass defaultAuthor isNil.
 	] ensure: [
-		SmalltalkCI setAuthor: currentAuthor.
-		self assert: SmalltalkCI getAuthor equals: currentAuthor ]
+		SmalltalkCI platformClass setAuthor: currentAuthor.
+		self assert: SmalltalkCI platformClass getAuthor equals: currentAuthor ]


### PR DESCRIPTION
This PR introduces two small changes to use updated versions of deprecated methods in Pharo 12, avoiding Debugger windows when running in interactive mode.

- Use `tags` instead of `classTags` (deprecated in Pharo12)
- Use `Author fullName:`  instead of `setAuthor` (deprecated in Pharo12).
- Changes in .json files are just a re-ordering of properties.