### PR TITLE
fix: change directory for Coveralls report

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -440,6 +440,8 @@ export_coveralls_data() {
   local service_pull_request=""
   local url="unknown"
 
+  pushd "${SMALLTALK_CI_BUILD}" > /dev/null
+
   if ! grep -q "#coverage" "${config_ston}"; then
     return 0 # Coverage data not needed
   fi
@@ -518,6 +520,9 @@ export_coveralls_data() {
   }
 }
 EOL
+
+
+popd  > /dev/null
 }
 
 upload_coveralls_results() {


### PR DESCRIPTION
In order to use `git` commands for generating the Coveralls report, the script needs to `cd` to `SMALLTALK_CI_HOME` first.

Fixes #626