### PR TITLE
Update lineup for GemStone and fix Issue #613

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,6 @@ jobs:
             smalltalk: GemStone64-3.6.8
           - os: windows-2019
             smalltalk: GemStone64-3.7.1
-    continue-on-error: ${{ matrix.os == 'macos-latest' && startsWith(matrix.smalltalk, 'GemStone64') }}
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.smalltalk }} on ${{ matrix.os }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,10 +46,9 @@ jobs:
           - Moose64-10
           - Moose64-9.0
           - Moose64-8.0
-          - GemStone64-3.5.3
           - GemStone64-3.5.8
-          - GemStone64-3.6.0
-          - GemStone64-3.6.5
+          - GemStone64-3.6.8
+          - GemStone64-3.7.1
           - GToolkit64-release
         exclude: # exclude 32bit builds on macOS and GemStone builds on windows
           - os: macos-latest
@@ -64,18 +63,20 @@ jobs:
             smalltalk: Pharo32-alpha
           - os: macos-latest
             smalltalk: Pharo32-3.0
+          - os: macos-latest
+            smalltalk: GemStone64-3.5.8
+          - os: macos-latest
+            smalltalk: GemStone64-3.6.8
           - os: windows-2019
             smalltalk: Pharo64-10
           - os: windows-2019
             smalltalk: Pharo64-6.0
           - os: windows-2019
-            smalltalk: GemStone64-3.5.3
-          - os: windows-2019
             smalltalk: GemStone64-3.5.8
           - os: windows-2019
-            smalltalk: GemStone64-3.6.0
+            smalltalk: GemStone64-3.6.8
           - os: windows-2019
-            smalltalk: GemStone64-3.6.5
+            smalltalk: GemStone64-3.7.1
     continue-on-error: ${{ matrix.os == 'macos-latest' && startsWith(matrix.smalltalk, 'GemStone64') }}
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.smalltalk }} on ${{ matrix.os }}


### PR DESCRIPTION
Fix for issue #613. Versions older than GemStone 3.7.1 will not run on macos-latest (14.x), adjust the lineup with expected failures and add 3.7.1.

My [CI run failed](https://github.com/dalehenrich/smalltalkCI/actions/runs/9045789613), however the failure was a [Squeak32-4.5 job timing out](https://github.com/dalehenrich/smalltalkCI/actions/runs/9045789613/job/24855908626) so I don't think my changes impacted the Squeak32 job.

