### PR TITLE
[Bug]: GToolkit Download Target Should Include Zip Extension

### DIFF
--- a/gtoolkit/run.sh
+++ b/gtoolkit/run.sh
@@ -108,26 +108,26 @@ gtoolkit::prepare_gt() {
   local download_name
   local target
   gtoolkit_image_url="$(gtoolkit::archive_url)"
-  smalltalk_name="$(basename "${gtoolkit_image_url}" .zip)"
+  smalltalk_version="$(basename "${gtoolkit_image_url}" .zip)"
   download_name="$(basename "${gtoolkit_image_url}")"
-  target="${SMALLTALK_CI_CACHE}/${smalltalk_name}"
+  target="${SMALLTALK_CI_CACHE}/${smalltalk_version}"
 
   if "${config_overwrite_cache}" && is_dir "${target}"; then
-    print_info "Removing cached image resources for ${smalltalk_name} (update forced)"
+    print_info "Removing cached image resources for ${smalltalk_version} (update forced)"
     rm -r "${target}"
   fi
   if ! is_dir "${target}"; then
     mkdir "${target}"
   fi
-  if ! is_file "${target}"/*.image; then
-    fold_start download_image "Downloading ${smalltalk_name} image..."
+  if ! is_file "${target}/${download_name}"; then
+    fold_start download_image "Downloading ${smalltalk_version}..."
       download_file "${gtoolkit_image_url}" "${target}/${download_name}"
     fold_end download_image
   fi
 
   print_info "Extracting GT..."
-  extract_file "${target}/${download_name}" "${SMALLTALK_CI_BUILD}"
-  echo "${smalltalk_name}" > "${SMALLTALK_CI_BUILD}"/version
+  extract_file "${target}/${download_name}" "${SMALLTALK_CI_BUILD}" > /dev/null
+  echo "${smalltalk_version}" > "${SMALLTALK_CI_BUILD}"/version
 
   print_info "Preparing GToolkit image..."
   if ! is_file "${SMALLTALK_CI_IMAGE}"; then

--- a/gtoolkit/run.sh
+++ b/gtoolkit/run.sh
@@ -107,6 +107,7 @@ gtoolkit::prepare_gt() {
   local gtoolkit_image_url
   local download_name
   local target
+  local smalltalk_version
   gtoolkit_image_url="$(gtoolkit::archive_url)"
   smalltalk_version="$(basename "${gtoolkit_image_url}" .zip)"
   download_name="$(basename "${gtoolkit_image_url}")"

--- a/gtoolkit/run.sh
+++ b/gtoolkit/run.sh
@@ -108,8 +108,9 @@ gtoolkit::prepare_gt() {
   local download_name
   local target
   gtoolkit_image_url="$(gtoolkit::archive_url)"
+  smalltalk_name="$(basename "${gtoolkit_image_url}" .zip)"
   download_name="$(basename "${gtoolkit_image_url}")"
-  target="${SMALLTALK_CI_CACHE}/${download_name}"
+  target="${SMALLTALK_CI_CACHE}/${smalltalk_name}"
 
   if "${config_overwrite_cache}" && is_dir "${target}"; then
     print_info "Removing cached image resources for ${smalltalk_name} (update forced)"
@@ -120,13 +121,13 @@ gtoolkit::prepare_gt() {
   fi
   if ! is_file "${target}"/*.image; then
     fold_start download_image "Downloading ${smalltalk_name} image..."
-      download_file "${gtoolkit_image_url}" "${target}"
+      download_file "${gtoolkit_image_url}" "${target}/${download_name}"
     fold_end download_image
   fi
 
   print_info "Extracting GT..."
-  extract_file "${target}" "${SMALLTALK_CI_BUILD}"
-  echo "${download_name}" > "${SMALLTALK_CI_BUILD}"/version
+  extract_file "${target}/${download_name}" "${SMALLTALK_CI_BUILD}"
+  echo "${smalltalk_name}" > "${SMALLTALK_CI_BUILD}"/version
 
   print_info "Preparing GToolkit image..."
   if ! is_file "${SMALLTALK_CI_IMAGE}"; then

--- a/gtoolkit/run.sh
+++ b/gtoolkit/run.sh
@@ -114,7 +114,7 @@ gtoolkit::prepare_gt() {
   target="${SMALLTALK_CI_CACHE}/${smalltalk_version}"
 
   if "${config_overwrite_cache}" && is_dir "${target}"; then
-    print_info "Removing cached image resources for ${smalltalk_version} (update forced)"
+    print_info "Removing cached image resources for ${smalltalk_name} (update forced)"
     rm -r "${target}"
   fi
   if ! is_dir "${target}"; then


### PR DESCRIPTION
Errors like the following were happening because the folder was being passed to curl instead of the file: Starting GToolkit build...
Downloading GToolkit64-release image...
curl: (23) Failure writing output to destination
curl failed to download https://github.com/feenkcom/gtoolkit/releases/download/v1.0.773/GlamorousToolkit-MacOS-aarch64-v1.0.773.zip to '~/Repositories/smalltalkCI/_cache/GlamorousToolkit-MacOS-aarch64-v1.0.773.zip'.