### PR TITLE
Create allPackageNames.st

### DIFF
--- a/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo.class/class/classesFrom..st
+++ b/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo.class/class/classesFrom..st
@@ -13,7 +13,10 @@ classesFrom: aDictionary
 				commandLineHandler addPackagesMatching: each to: packages ].
 			packages do: [ :each |
 				| package |
-				package := (Smalltalk at: #RPackageOrganizer) default packageNamed: each.
-				classes addAll: package definedClasses ] ].
+				package := self
+					packageNamed: each
+					ifAbsent: [ nil ].
+				package ifNotNil: [
+					classes addAll: package definedClasses ] ] ].
 
 	^ classes	

--- a/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo13.class/class/allPackageNames.st
+++ b/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo13.class/class/allPackageNames.st
@@ -1,0 +1,3 @@
+class organization
+allPackageNames
+	^ (Smalltalk globals at: #PackageOrganizer) default packageNames

--- a/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo13.class/class/codeCoverageClass.st
+++ b/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo13.class/class/codeCoverageClass.st
@@ -1,0 +1,4 @@
+compatibility
+codeCoverageClass
+
+	^ Smalltalk at: #SCIPharo13CodeCoverage

--- a/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo13.class/class/packageNamed.ifAbsent..st
+++ b/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo13.class/class/packageNamed.ifAbsent..st
@@ -1,0 +1,3 @@
+class organization
+packageNamed: aString ifAbsent: errorBlock
+	^ (Smalltalk at: #PackageOrganizer) default packageNamed: aString ifAbsent: errorBlock

--- a/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo13.class/methodProperties.json
+++ b/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo13.class/methodProperties.json
@@ -1,6 +1,8 @@
 {
 	"class" : {
+		"allPackageNames" : "MaxLeske 6/11/2024 20:01",
 		"codeCoverageClass" : "MaxLeske 4/29/2024 19:25",
+		"packageNamed:ifAbsent:" : "MaxLeske 6/11/2024 20:01",
 		"isPlatformCompatible" : "MaxLeske 4/29/2024 19:25"},
 	"instance" : {
 		 } }

--- a/repository/SmalltalkCI-Pharo-Coverage-Core.package/SCIPharo13CodeCoverage.class/class/packageNameForClass..st
+++ b/repository/SmalltalkCI-Pharo-Coverage-Core.package/SCIPharo13CodeCoverage.class/class/packageNameForClass..st
@@ -1,0 +1,3 @@
+compatibility
+packageNameForClass: aClass
+	^ ((Smalltalk at: #PackageOrganizer) default packageOf: aClass) name

--- a/repository/SmalltalkCI-Pharo-Coverage-Core.package/SCIPharo13CodeCoverage.class/properties.json
+++ b/repository/SmalltalkCI-Pharo-Coverage-Core.package/SCIPharo13CodeCoverage.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "SCIPharo12CodeCoverage",
+	"category" : "SmalltalkCI-Pharo-Coverage-Core",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "SCIPharo13CodeCoverage",
+	"type" : "normal"
+}


### PR DESCRIPTION
RPackageOrganizer was deprecated in Pharo12 and removed in Pharo13