### PR TITLE
feat: report image info without `StSystemReporter`

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -70,7 +70,7 @@ print_help() {
     --headful               Open vm in headful mode and do not close image.
     --image                 Custom image for build (Squeak/Pharo).
     --install               Install symlink to this smalltalkCI instance.
-    --overwrite-cache   Download the newest image and cache it.
+    --overwrite-cache       Download the newest image and cache it.
     --print-env             Print all environment variables used by smalltalkCI
     --no-color              Disable colored output
     --no-tracking           Disable collection of anonymous build metrics (Travis CI & AppVeyor only).

--- a/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo11.class/class/newTravisID.st
+++ b/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo11.class/class/newTravisID.st
@@ -1,6 +1,4 @@
 instance creation
 newTravisID
 	"Random and image-specific identifier for Travis folds"
-	| r |
-	r := Random new.
-	^ (ByteArray with: (r nextInteger: 255) with: (r nextInteger: 255)) hex
+	^ (ByteArray with: 255 atRandom with: 255 atRandom) hex

--- a/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo13.class/instance/imageInfo.st
+++ b/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo13.class/instance/imageInfo.st
@@ -1,0 +1,7 @@
+reporting
+imageInfo
+^ String new: 210 streamContents: [ :stream |
+	stream 
+		nextPutAll: Smalltalk image imagePath; cr;
+		nextPutAll: SystemVersion current version; cr;
+		nextPutAll: Smalltalk image lastUpdateString; cr ]

--- a/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo13.class/methodProperties.json
+++ b/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo13.class/methodProperties.json
@@ -3,6 +3,9 @@
 		"allPackageNames" : "MaxLeske 6/11/2024 20:01",
 		"codeCoverageClass" : "MaxLeske 4/29/2024 19:25",
 		"packageNamed:ifAbsent:" : "MaxLeske 6/11/2024 20:01",
-		"isPlatformCompatible" : "MaxLeske 4/29/2024 19:25"},
+		"isPlatformCompatible" : "MaxLeske 4/29/2024 19:25"
+	},
 	"instance" : {
-		 } }
+		"imageInfo" : "MaxLeske 6/15/2024 07:51"
+	}
+}


### PR DESCRIPTION
`StSystemReporter` was removed in Pharo 13.