### PR TITLE
Rename env variable for GitLab build

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -490,8 +490,8 @@ export_coveralls_data() {
     url="https://github.com/${APPVEYOR_REPO_NAME}.git"
   elif is_gitlabci_build; then
     branch_name="${CI_COMMIT_REF_NAME}"
-    service_job_id="${CI_BUILD_ID}"
-    service_job_number="${CI_BUILD_NAME}"
+    service_job_id="${CI_JOB_ID}"
+    service_job_number="${CI_JOB_NAME}"
     service_name="gitlab-ci"
     service_pull_request="${CI_MERGE_REQUEST_IID:-}"
     url="${CI_PROJECT_URL}"

--- a/helpers.sh
+++ b/helpers.sh
@@ -490,8 +490,8 @@ export_coveralls_data() {
     url="https://github.com/${APPVEYOR_REPO_NAME}.git"
   elif is_gitlabci_build; then
     branch_name="${CI_COMMIT_REF_NAME}"
-    service_job_id="${CI_JOB_ID}"
-    service_job_number="${CI_JOB_NAME}"
+    service_job_id="${CI_JOB_ID:-CI_BUILD_ID}"
+    service_job_number="${CI_JOB_NAME:-CI_BUILD_NAME}"
     service_name="gitlab-ci"
     service_pull_request="${CI_MERGE_REQUEST_IID:-}"
     url="${CI_PROJECT_URL}"


### PR DESCRIPTION
The environment variable has been rename on GitLab. Deprecated in version 9.x and removed now.

I think we can replace them in the script now.
It creates bugs 

see https://github.com/fsprojects/FAKE/issues/2290#issuecomment-522197031