### PR TITLE
Add Moose 13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
           - Pharo32-stable
           - Pharo32-alpha
           - Pharo32-3.0
+          - Moose64-13
           - Moose64-12
           - Moose64-11
           - Moose64-10

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ they can take up a lot of space on your drive.*
 | [Squeak][squeak] | [Pharo][pharo]   | [GemStone][gemstone] | [Moose][moose]  | [GToolkit][gtoolkit] |
 | ---------------- | ---------------- | -------------------- | --------------- | -------------------- |
 | `Squeak64-trunk` | `Pharo64-alpha`  | `GemStone64-3.6.x`   | `Moose64-trunk` | `GToolkit64-release` |
-| `Squeak64-6.0`   | `Pharo64-stable` | `GemStone64-3.5.8`   | `Moose64-12`    |                      |
-| `Squeak64-5.3`   | `Pharo64-13`     | `GemStone64-3.5.7`   | `Moose64-11`    |                      |
-| `Squeak64-5.2`   | `Pharo64-12`     | `GemStone64-3.5.6`   | `Moose64-10`    |                      |
-| `Squeak64-5.1`   | `Pharo64-11`     | `GemStone64-3.5.5`   | `Moose64-9.0`   |                      |
-| `Squeak32-trunk` | `Pharo64-10`     | `Gemstone64-3.5.4`   | `Moose64-8.0`   |                      |
-| `Squeak32-6.0`   | `Pharo64-9.0`    | `GemStone64-3.5.3`   |                 |                      |
+| `Squeak64-6.0`   | `Pharo64-stable` | `GemStone64-3.5.8`   | `Moose64-13`    |                      |
+| `Squeak64-5.3`   | `Pharo64-13`     | `GemStone64-3.5.7`   | `Moose64-12`    |                      |
+| `Squeak64-5.2`   | `Pharo64-12`     | `GemStone64-3.5.6`   | `Moose64-11`    |                      |
+| `Squeak64-5.1`   | `Pharo64-11`     | `GemStone64-3.5.5`   | `Moose64-10`    |                      |
+| `Squeak32-trunk` | `Pharo64-10`     | `Gemstone64-3.5.4`   | `Moose64-9.0`   |                      |
+| `Squeak32-6.0`   | `Pharo64-9.0`    | `GemStone64-3.5.3`   | `Moose64-8.0`   |                      |
 | `Squeak32-5.3`   | `Pharo64-8.0`    |                      |                 |                      |
 | `Squeak32-5.2`   | `Pharo64-7.0`    |                      |                 |                      |
 | `Squeak32-5.1`   | `Pharo64-6.1`    |                      |                 |                      |

--- a/pharo/run.sh
+++ b/pharo/run.sh
@@ -109,7 +109,7 @@ moose::get_image_url() {
 
   case "${smalltalk_name}" in
     "Moose64-trunk"|"Moose-trunk")
-      echo "https://github.com/moosetechnology/Moose/releases/download/continuous/Moose12-development-Pharo64-12.zip"
+      echo "https://github.com/moosetechnology/Moose/releases/download/continuous/Moose13-development-Pharo64-13.zip"
       ;;
     "Moose64-8"*)
       echo "https://github.com/moosetechnology/Moose/releases/download/v8.x.x/Moose8-old-stable-Pharo64-8.0.zip"
@@ -124,7 +124,10 @@ moose::get_image_url() {
       echo "https://github.com/moosetechnology/Moose/releases/download/v11.x.x/Moose11-stable-Pharo64-11.zip"
       ;;
     "Moose64-12"*)
-      echo "https://github.com/moosetechnology/Moose/releases/download/continuous/Moose12-development-Pharo64-12.zip"
+      echo "https://github.com/moosetechnology/Moose/releases/download/v12.0.0/Moose12-stable-Pharo64-12.zip"
+      ;;
+    "Moose64-13"*)
+      echo "https://github.com/moosetechnology/Moose/releases/download/continuous/Moose13-development-Pharo64-13.zip"
       ;;
     *)
       print_error_and_exit "Unsupported Moose version '${smalltalk_name}'."
@@ -153,10 +156,10 @@ pharo::get_vm_url() {
     "Pharo64-stable"|"Pharo-stable")
       echo "get.pharo.org/64/vm${stable_version}0"
       ;;
-    "Pharo64-13")
+    "Pharo64-13"|"Moose64-13"|"Moose64-trunk")
       echo "get.pharo.org/64/vm130"
       ;;
-    "Pharo64-12"|"Moose64-12"|"Moose64-trunk")
+    "Pharo64-12"|"Moose64-12")
       echo "get.pharo.org/64/vm120"
       ;;
     "Pharo64-11"|"Moose64-11")

--- a/run.sh
+++ b/run.sh
@@ -228,7 +228,7 @@ select_smalltalk() {
                 Pharo32-4.0 Pharo32-3.0
                 GemStone64-3.6.5 GemStone64-3.6.0 GemStone64-3.5.8 GemStone64-3.5.3
                 GToolkit64-release
-                Moose64-trunk Moose64-12 Moose64-11 Moose64-10 Moose64-9.0 Moose64-8.0"
+                Moose64-trunk Moose64-13 Moose64-12 Moose64-11 Moose64-10 Moose64-9.0 Moose64-8.0"
 
   if is_not_empty "${config_smalltalk}"; then
     return


### PR DESCRIPTION
Moose 12 has been released as stable.
Moose 13 is the dev version. It runs on Pharo 13.