### PR TITLE
chore: update Linux runner on GitHub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-latest, windows-2019 ]
+        os: [ ubuntu-latest, macos-latest, windows-2019 ]
         smalltalk:
           - Squeak64-trunk
           - Squeak64-6.0


### PR DESCRIPTION
Ubuntu 20.04 has been deprecated