### PR TITLE
Add the #silently option of Metacello

### DIFF
--- a/repository/SmalltalkCI-Core.package/SCIMetacelloLoadSpec.class/instance/basicLoadProjectOn..st
+++ b/repository/SmalltalkCI-Core.package/SCIMetacelloLoadSpec.class/instance/basicLoadProjectOn..st
@@ -7,6 +7,7 @@ basicLoadProjectOn: aSmalltalkCI
 	
 	metacello := (Smalltalk at: #Metacello) new.
 	metacello
+		silently;
 		repository: (self repository ifNil: [ 
 			self repositoryUrlIn: aSmalltalkCI projectDirectory ]);
 		baseline: self baseline;

--- a/repository/SmalltalkCI-Core.package/SCIMetacelloLoadSpec.class/methodProperties.json
+++ b/repository/SmalltalkCI-Core.package/SCIMetacelloLoadSpec.class/methodProperties.json
@@ -7,7 +7,7 @@
 	"instance" : {
 		"baseline" : "fn 1/10/2016 11:44",
 		"baseline:" : "fn 1/10/2016 11:44",
-		"basicLoadProjectOn:" : "ct 3/25/2021 15:36",
+		"basicLoadProjectOn:" : "CyrilFerlicot 01/03/2026 1:15",
 		"configuration" : "fn 1/10/2016 11:45",
 		"configuration:" : "fn 1/10/2016 11:44",
 		"directory" : "fn 8/28/2016 19:20",


### PR DESCRIPTION
SmalltalkCI is running mostly in CIs and updating the progress bars can take some time.

The load time can be reduced I think if we use Metacello silently