### PR TITLE
Update OSVM versions for Squeak>=5.3

### DIFF
--- a/squeak/run.sh
+++ b/squeak/run.sh
@@ -165,18 +165,14 @@ squeak::get_vm_details() {
   local vm_path_linux_name=""
   local vm_path_linux_suffix="ht"
 
+  git_tag="v3.0.8"
+  osvm_version="202312181441"
   if is_trunk_build; then
-    git_tag="v2.9.9"
-    osvm_version="202206021410"
+    : # use defaults above
   else
     case "${smalltalk_name}" in
-      "Squeak32-6.0"|"Squeak64-6.0")
-        git_tag="v2.9.9"
-        osvm_version="202206021410"
-        ;;
-      "Squeak64-5.3")
-        git_tag="v2.9.1"
-        osvm_version="202003021730"
+      "Squeak32-6.1"|"Squeak64-6.1"|"Squeak32-6.0"|"Squeak64-6.0"|"Squeak32-5.3"|"Squeak64-5.3")
+        # use defaults above
         ;;
       *)
         git_tag="v2.8.4"

--- a/tests/squeak_tests.sh
+++ b/tests/squeak_tests.sh
@@ -25,28 +25,28 @@ test_get_vm_details() {
   set_vars vm_filename vm_path git_tag "${vm_details}"
   assert_vm_filename "${vm_filename}" "squeak.cog.spur_linux64x64_"
   assertEquals "${config_vm_dir}/sqcogspur64linuxht/squeak" "${vm_path}"
-  starts_with "${git_tag}" "v2" || fail "Unexpected git_tag: '${git_tag}'"
+  starts_with "${git_tag}" "v3" || fail "Unexpected git_tag: '${git_tag}'"
 
   config_smalltalk="Squeak64-6.0"
   vm_details="$(squeak::get_vm_details "${config_smalltalk}" "Linux" 1)"
   set_vars vm_filename vm_path git_tag "${vm_details}"
   assert_vm_filename "${vm_filename}" "squeak.cog.spur_linux64x64_"
   assertEquals "${config_vm_dir}/sqcogspur64linuxht/squeak" "${vm_path}"
-  starts_with "${git_tag}" "v2" || fail "Unexpected git_tag: '${git_tag}'"
+  starts_with "${git_tag}" "v3" || fail "Unexpected git_tag: '${git_tag}'"
 
   config_smalltalk="Squeak32-6.0"
   vm_details="$(squeak::get_vm_details "${config_smalltalk}" "Linux" 1)"
   set_vars vm_filename vm_path git_tag "${vm_details}"
   assert_vm_filename "${vm_filename}" "squeak.cog.spur_linux32x86_"
   assertEquals "${config_vm_dir}/sqcogspur32linuxht/squeak" "${vm_path}"
-  starts_with "${git_tag}" "v2" || fail "Unexpected git_tag: '${git_tag}'"
+  starts_with "${git_tag}" "v3" || fail "Unexpected git_tag: '${git_tag}'"
 
   config_smalltalk="Squeak64-5.3"
   vm_details="$(squeak::get_vm_details "${config_smalltalk}" "Linux" 1)"
   set_vars vm_filename vm_path git_tag "${vm_details}"
   assert_vm_filename "${vm_filename}" "squeak.cog.spur_linux64x64_"
   assertEquals "${config_vm_dir}/sqcogspur64linuxht/squeak" "${vm_path}"
-  starts_with "${git_tag}" "v2" || fail "Unexpected git_tag: '${git_tag}'"
+  starts_with "${git_tag}" "v3" || fail "Unexpected git_tag: '${git_tag}'"
 
   config_smalltalk="Squeak32-5.2"
   vm_details="$(squeak::get_vm_details "${config_smalltalk}" "Linux" 0)"
@@ -60,7 +60,7 @@ test_get_vm_details() {
   set_vars vm_filename vm_path git_tag "${vm_details}"
   assert_vm_filename "${vm_filename}" "squeak.cog.spur_macos64x64_"
   assertEquals "${config_vm_dir}/Squeak.app/Contents/MacOS/Squeak" "${vm_path}"
-  starts_with "${git_tag}" "v2" || fail "Unexpected git_tag: '${git_tag}'"
+  starts_with "${git_tag}" "v3" || fail "Unexpected git_tag: '${git_tag}'"
 
   config_smalltalk="Squeak64-5.2"
   vm_details="$(squeak::get_vm_details "${config_smalltalk}" "Darwin" 1)"
@@ -75,19 +75,19 @@ test_get_vm_details() {
   set_vars vm_filename vm_path git_tag "${vm_details}"
   assert_vm_filename "${vm_filename}" "squeak.cog.v3_macos64x64_"
   assertEquals "${config_vm_dir}/Squeak.app/Contents/MacOS/Squeak" "${vm_path}"
-  starts_with "${git_tag}" "v2" || fail "Unexpected git_tag: '${git_tag}'"
+  starts_with "${git_tag}" "v3" || fail "Unexpected git_tag: '${git_tag}'"
 
   vm_details="$(squeak::get_vm_details "${config_smalltalk}" "CYGWIN_NT-6.1" 1)"
   set_vars vm_filename vm_path git_tag "${vm_details}"
   assert_vm_filename "${vm_filename}" "squeak.cog.spur_win64x64_"
   assertEquals "${config_vm_dir}/SqueakConsole.exe" "${vm_path}"
-  starts_with "${git_tag}" "v2" || fail "Unexpected git_tag: '${git_tag}'"
+  starts_with "${git_tag}" "v3" || fail "Unexpected git_tag: '${git_tag}'"
 
   vm_details="$(squeak::get_vm_details "${config_smalltalk}" "CYGWIN_NT-6.1" 0)"
   set_vars vm_filename vm_path git_tag "${vm_details}"
   assert_vm_filename "${vm_filename}" "squeak.cog.v3_win64x64_"
   assertEquals "${config_vm_dir}/SqueakConsole.exe" "${vm_path}"
-  starts_with "${git_tag}" "v2" || fail "Unexpected git_tag: '${git_tag}'"
+  starts_with "${git_tag}" "v3" || fail "Unexpected git_tag: '${git_tag}'"
 
   set +e
   $(filename="$(squeak::get_vm_details "Squeak64-trunk" "Linux" 2>/dev/null)") \


### PR DESCRIPTION
All of these versions come bundled with the OSVM version [202312181441](https://github.com/OpenSmalltalk/opensmalltalk-vm/releases/tag/202312181441) since 2024-01-12:
- Squeak5.3 [32-bit](https://files.squeak.org/5.3/Squeak5.3-19486-32bit/), [64-bit](https://files.squeak.org/5.3/Squeak5.3-19486-64bit/)
- Squeak6.0 [32-bit](https://files.squeak.org/6.0/Squeak6.0-22147-32bit/), [64-bit](https://files.squeak.org/6.0/Squeak6.0-22147-32bit/)
- Squeak6.1 [32-bit](https://files.squeak.org/6.1alpha/Squeak6.1alpha-22938-32bit/), [64-bit](https://files.squeak.org/6.1alpha/Squeak6.1alpha-22938-64bit/)
- Squeak-Trunk [32-bit](https://files.squeak.org/trunk/Squeak6.1alpha-22938-32bit/), [64-bit](https://files.squeak.org/trunk/Squeak6.1alpha-22938-64bit/)

Note that Squeak32-5.3 was previously not included in the "newer VM" list (since 9b565765fd1c29d5eddb50b60883927a3754a2cc), but is included now. Please tell me if that is wrong (excluding it was intended), then I'll adjust the PR.

Also note that this will require a new release of smalltalkCI, to include the new VM builds.
This PR assumes that the release will be called v3.0.8.

Fixes #675.

I have tested this change on git/s:
- the old smalltalkCI hangs on [5.2](https://github.com/hpi-swa/git-s/actions/runs/24602822207/job/71944227958) and [5.3](https://github.com/hpi-swa/git-s/actions/runs/24602822207/job/71944227947)
- with this PR (and a temporary fix to download from the OSVM repo instead of this repo), the CI runs on [5.3](https://github.com/hpi-swa/git-s/actions/runs/24603283056/job/71948369538) (my tests are failing, but importantly the CI runs to completion)

This PR doesn't touch Squeak5.2, because that is still bundled with OSVM version 201810190412 ([32-bit](https://files.squeak.org/5.2/Squeak5.2-18234-32bit/), [64-bit](https://files.squeak.org/5.2/Squeak5.2-18234-64bit/)).