### PR TITLE
pharo: update versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,10 +37,6 @@ jobs:
           - Pharo64-11
           - Pharo64-10
           - Pharo64-9.0
-          - Pharo64-8.0
-          - Pharo64-7.0
-          - Pharo64-6.1
-          - Pharo64-6.0
           - Pharo32-stable
           - Pharo32-alpha
           - Pharo32-3.0
@@ -49,7 +45,6 @@ jobs:
           - Moose64-11
           - Moose64-10
           - Moose64-9.0
-          - Moose64-8.0
           - GemStone64-3.5.8
           - GemStone64-3.6.8
           - GemStone64-3.7.1
@@ -73,8 +68,6 @@ jobs:
             smalltalk: GemStone64-3.6.8
           - os: windows-2019
             smalltalk: Pharo64-10
-          - os: windows-2019
-            smalltalk: Pharo64-6.0
           - os: windows-2019
             smalltalk: GemStone64-3.5.8
           - os: windows-2019

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,10 +66,6 @@ jobs:
     - smalltalk: Squeak32-4.6
     - smalltalk: Squeak32-4.5
     - smalltalk: Pharo64-9.0
-    - smalltalk: Pharo64-8.0
-    - smalltalk: Pharo64-7.0
-    - smalltalk: Pharo64-6.1
-    - smalltalk: Pharo64-6.0
     - smalltalk: Pharo32-9.0
     - smalltalk: Pharo32-8.0
     - smalltalk: Pharo32-7.0
@@ -78,8 +74,6 @@ jobs:
     - smalltalk: Pharo32-5.0
     - smalltalk: Pharo32-4.0
     - smalltalk: Pharo32-3.0
-    - smalltalk: Moose64-8.0
-    - smalltalk: Moose64-7.0
     - smalltalk: Moose32-7.0
     - smalltalk: Moose32-6.0
     - smalltalk: GemStone64-3.4.3

--- a/README.md
+++ b/README.md
@@ -80,17 +80,13 @@ they can take up a lot of space on your drive.*
 | `Squeak64-5.2`   | `Pharo64-13`     | `GemStone64-3.5.7`   | `Moose64-11`    |                      |
 | `Squeak64-5.1`   | `Pharo64-12`     | `GemStone64-3.5.6`   | `Moose64-10`    |                      |
 | `Squeak32-trunk` | `Pharo64-11`     | `GemStone64-3.5.5`   | `Moose64-9.0`   |                      |
-| `Squeak32-6.0`   | `Pharo64-10`     | `Gemstone64-3.5.4`   | `Moose64-8.0`   |                      |
+| `Squeak32-6.0`   | `Pharo64-10`     | `Gemstone64-3.5.4`   |                 |                      |
 | `Squeak32-5.3`   | `Pharo64-9.0`    | `GemStone64-3.5.3`   |                 |                      |
-| `Squeak32-5.2`   | `Pharo64-8.0`    |                      |                 |                      |
-| `Squeak32-5.1`   | `Pharo64-7.0`    |                      |                 |                      |
-| `Squeak32-5.0`   | `Pharo64-6.1`    |                      |                 |                      |
-| `Squeak32-4.6`   | `Pharo64-6.0`    |                      |                 |                      |
-| `Squeak32-4.5`   | `Pharo32-alpha`  |                      |                 |                      |
-|                  | `Pharo32-stable` |                      |                 |                      |
-|                  | `Pharo32-14`     |                      |                 |                      |
-|                  | `Pharo32-13`     |                      |                 |                      |
-|                  | `Pharo32-12`     |                      |                 |                      |
+| `Squeak32-5.2`   | `Pharo32-alpha`  |                      |                 |                      |
+| `Squeak32-5.1`   | `Pharo32-stable` |                      |                 |                      |
+| `Squeak32-5.0`   | `Pharo32-14`     |                      |                 |                      |
+| `Squeak32-4.6`   | `Pharo32-13`     |                      |                 |                      |
+| `Squeak32-4.5`   | `Pharo32-12`     |                      |                 |                      |
 |                  | `Pharo32-11`     |                      |                 |                      |
 |                  | `Pharo32-10`     |                      |                 |                      |
 |                  | `Pharo32-9.0`    |                      |                 |                      |
@@ -101,6 +97,10 @@ they can take up a lot of space on your drive.*
 |                  | `Pharo32-5.0`    |                      |                 |                      |
 |                  | `Pharo32-4.0`    |                      |                 |                      |
 |                  | `Pharo32-3.0`    |                      |                 |                      |
+|                  |                  |                      |                 |                      |
+|                  |                  |                      |                 |                      |
+|                  |                  |                      |                 |                      |
+|                  |                  |                      |                 |                      |
 
 ## Templates
 
@@ -175,8 +175,8 @@ smalltalk:
   # ...
   - Pharo64-alpha
   - Pharo64-stable
-  - Pharo64-7.0
-  - Pharo64-6.1
+  - Pharo64-13
+  - Pharo64-12
   # ...
   - Pharo32-alpha
   - Pharo32-stable

--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -218,7 +218,7 @@ stages:
 
 run tests:
   stage: test
-  script: smalltalkci -s "Pharo64-8.0"
+  script: smalltalkci -s "Pharo64-9.0"
   artifacts:
     paths:
       - $COVERAGE_DIR

--- a/pharo/run.sh
+++ b/pharo/run.sh
@@ -42,18 +42,7 @@ pharo::get_image_url() {
     "Pharo64-9.0")
       echo "get.pharo.org/64/90"
       ;;
-    "Pharo64-8.0")
-      echo "get.pharo.org/64/80"
-      ;;
-    "Pharo64-7.0")
-      echo "get.pharo.org/64/70"
-      ;;
-    "Pharo64-6.1")
-      echo "get.pharo.org/64/61"
-      ;;
-    "Pharo64-6.0")
-      echo "get.pharo.org/64/60"
-      ;;
+
     "Pharo32-alpha")
       echo "get.pharo.org/alpha"
       ;;
@@ -117,7 +106,6 @@ pharo::get_image_url() {
 ################################################################################
 moose::get_image_url() {
   local smalltalk_name=$1
-  local moose_name
 
   case "${smalltalk_name}" in
     "Moose64-trunk"|"Moose-trunk")
@@ -189,18 +177,7 @@ pharo::get_vm_url() {
     "Pharo64-9.0"|"Moose64-9.0")
       echo "get.pharo.org/64/vm90"
       ;;
-    "Pharo64-8.0"|"Moose64-8.0")
-      echo "get.pharo.org/64/vm80"
-      ;;
-    "Pharo64-7.0")
-      echo "get.pharo.org/64/vm70"
-      ;;
-    "Pharo64-6.1")
-      echo "get.pharo.org/64/vm61"
-      ;;
-    "Pharo64-6.0")
-      echo "get.pharo.org/64/vm60"
-      ;;
+
     "Pharo32-alpha")
       echo "get.pharo.org/vmLatest${alpha_version}0"
       ;;

--- a/pharo/run.sh
+++ b/pharo/run.sh
@@ -21,6 +21,9 @@ pharo::get_image_url() {
     "Pharo64-stable"|"Pharo-stable")
       echo "get.pharo.org/64/stable"
       ;;
+    "Pharo64-15")
+      echo "get.pharo.org/64/150"
+      ;;
     "Pharo64-14")
       echo "get.pharo.org/64/140"
       ;;
@@ -57,6 +60,9 @@ pharo::get_image_url() {
     "Pharo32-stable")
       echo "get.pharo.org/stable"
       ;;
+    "Pharo32-15")
+        echo "get.pharo.org/32/150"
+        ;;
     "Pharo32-14")
         echo "get.pharo.org/32/140"
         ;;
@@ -151,8 +157,8 @@ moose::get_image_url() {
 ################################################################################
 pharo::get_vm_url() {
   local smalltalk_name=$1
-  local stable_version=12
-  local alpha_version=13
+  local stable_version=13
+  local alpha_version=14
 
   case "${smalltalk_name}" in
     # NOTE: vmLatestXX should be updated every time new Pharo is released
@@ -161,6 +167,9 @@ pharo::get_vm_url() {
       ;;
     "Pharo64-stable"|"Pharo-stable")
       echo "get.pharo.org/64/vm${stable_version}0"
+      ;;
+    "Pharo64-15")
+      echo "get.pharo.org/64/vm150"
       ;;
     "Pharo64-14")
       echo "get.pharo.org/64/vm140"
@@ -197,6 +206,9 @@ pharo::get_vm_url() {
       ;;
     "Pharo32-stable")
       echo "get.pharo.org/vm${stable_version}0"
+      ;;
+    "Pharo32-15")
+      echo "get.pharo.org/vm150"
       ;;
     "Pharo32-14")
       echo "get.pharo.org/vm140"

--- a/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo14.class/class/promptToProceedImpl.st
+++ b/repository/SmalltalkCI-Pharo-Core.package/SmalltalkCIPharo14.class/class/promptToProceedImpl.st
@@ -1,0 +1,13 @@
+helpers
+promptToProceedImpl
+	| query |
+	query := 'smalltalkCI has finished loading the project. The image is now ready for testing.
+If you choose to inspect the image, you must save and quit the image to proceed.'.
+	
+	(ProvideAnswerNotification signal: query) ifNotNil: [ :answer |
+		^ answer ].
+	
+	^ UIManager default
+	      confirm: query
+			trueChoice: 'Proceed'
+			falseChoice: 'Inspect image'

--- a/run.sh
+++ b/run.sh
@@ -223,12 +223,12 @@ select_smalltalk() {
   local images="Squeak64-trunk Squeak64-6.0 Squeak64-5.3 Squeak64-5.2 Squeak64-5.1
                 Squeak32-trunk Squeak32-6.0 Squeak32-5.3 Squeak32-5.2 Squeak32-5.1 Squeak32-5.0
                 Squeak32-4.6 Squeak32-4.5
-                Pharo64-stable Pharo64-alpha Pharo64-13 Pharo64-12 Pharo64-11 Pharo64-10 Pharo64-9.0 Pharo64-8.0 Pharo64-7.0 Pharo64-6.1 Pharo64-6.0
-                Pharo32-stable Pharo32-alpha Pharo32-13 Pharo32-12 Pharo32-9.0 Pharo32-8.0 Pharo32-7.0 Pharo32-6.0 Pharo32-5.0
+                Pharo64-stable Pharo64-alpha Pharo64-15 Pharo64-14 Pharo64-13 Pharo64-12 Pharo64-11 Pharo64-10 Pharo64-9.0
+                Pharo32-stable Pharo32-alpha Pharo32-15 Pharo32-14 Pharo32-13 Pharo32-12 Pharo32-9.0 Pharo32-8.0 Pharo32-7.0 Pharo32-6.0 Pharo32-5.0
                 Pharo32-4.0 Pharo32-3.0
                 GemStone64-3.6.5 GemStone64-3.6.0 GemStone64-3.5.8 GemStone64-3.5.3
                 GToolkit64-release
-                Moose64-trunk Moose64-13 Moose64-12 Moose64-11 Moose64-10 Moose64-9.0 Moose64-8.0"
+                Moose64-trunk Moose64-13 Moose64-12 Moose64-11 Moose64-10 Moose64-9.0"
 
   if is_not_empty "${config_smalltalk}"; then
     return

--- a/tests/pharo_tests.sh
+++ b/tests/pharo_tests.sh
@@ -40,9 +40,6 @@ test_get_image_url() {
   image_url="$(pharo::get_image_url "Pharo64-9.0")"
   assertEquals "get.pharo.org/64/90" "${image_url}"
 
-  image_url="$(pharo::get_image_url "Pharo64-8.0")"
-  assertEquals "get.pharo.org/64/80" "${image_url}"
-
 
   image_url="$(pharo::get_image_url "Pharo32-15")"
   assertEquals "get.pharo.org/32/150" "${image_url}"
@@ -128,9 +125,6 @@ test_get_vm_url() {
 
   vm_url="$(pharo::get_vm_url "Pharo64-9.0")"
   assertEquals "get.pharo.org/64/vm90" "${vm_url}"
-
-  vm_url="$(pharo::get_vm_url "Pharo64-8.0")"
-  assertEquals "get.pharo.org/64/vm80" "${vm_url}"
 
 
   vm_url="$(pharo::get_vm_url "Pharo32-15")"

--- a/tests/pharo_tests.sh
+++ b/tests/pharo_tests.sh
@@ -19,6 +19,15 @@ test_get_image_url() {
   image_url="$(pharo::get_image_url "Pharo64-stable")"
   assertEquals "get.pharo.org/64/stable" "${image_url}"
 
+  image_url="$(pharo::get_image_url "Pharo64-15")"
+  assertEquals "get.pharo.org/64/150" "${image_url}"
+
+  image_url="$(pharo::get_image_url "Pharo64-14")"
+  assertEquals "get.pharo.org/64/140" "${image_url}"
+
+  image_url="$(pharo::get_image_url "Pharo64-13")"
+  assertEquals "get.pharo.org/64/130" "${image_url}"
+
   image_url="$(pharo::get_image_url "Pharo64-12")"
   assertEquals "get.pharo.org/64/120" "${image_url}"
 
@@ -34,6 +43,15 @@ test_get_image_url() {
   image_url="$(pharo::get_image_url "Pharo64-8.0")"
   assertEquals "get.pharo.org/64/80" "${image_url}"
 
+
+  image_url="$(pharo::get_image_url "Pharo32-15")"
+  assertEquals "get.pharo.org/32/150" "${image_url}"
+
+  image_url="$(pharo::get_image_url "Pharo32-14")"
+  assertEquals "get.pharo.org/32/140" "${image_url}"
+
+  image_url="$(pharo::get_image_url "Pharo32-13")"
+  assertEquals "get.pharo.org/32/130" "${image_url}"
 
   image_url="$(pharo::get_image_url "Pharo32-12")"
   assertEquals "get.pharo.org/32/120" "${image_url}"
@@ -79,16 +97,22 @@ test_get_vm_url() {
   local vm_url
 
   vm_url="$(pharo::get_vm_url "Pharo32-alpha")"
-  assertEquals "get.pharo.org/vmLatest130" "${vm_url}"
+  assertEquals "get.pharo.org/vmLatest140" "${vm_url}"
 
   vm_url="$(pharo::get_vm_url "Pharo64-alpha")"
-  assertEquals "get.pharo.org/64/vmLatest130" "${vm_url}"
+  assertEquals "get.pharo.org/64/vmLatest140" "${vm_url}"
 
   vm_url="$(pharo::get_vm_url "Pharo32-stable")"
-  assertEquals "get.pharo.org/vm120" "${vm_url}"
+  assertEquals "get.pharo.org/vm130" "${vm_url}"
 
   vm_url="$(pharo::get_vm_url "Pharo64-stable")"
-  assertEquals "get.pharo.org/64/vm120" "${vm_url}"
+  assertEquals "get.pharo.org/64/vm130" "${vm_url}"
+
+  vm_url="$(pharo::get_vm_url "Pharo64-15")"
+  assertEquals "get.pharo.org/64/vm150" "${vm_url}"
+  
+  vm_url="$(pharo::get_vm_url "Pharo64-14")"
+  assertEquals "get.pharo.org/64/vm140" "${vm_url}"
 
   vm_url="$(pharo::get_vm_url "Pharo64-13")"
   assertEquals "get.pharo.org/64/vm130" "${vm_url}"
@@ -108,6 +132,12 @@ test_get_vm_url() {
   vm_url="$(pharo::get_vm_url "Pharo64-8.0")"
   assertEquals "get.pharo.org/64/vm80" "${vm_url}"
 
+
+  vm_url="$(pharo::get_vm_url "Pharo32-15")"
+  assertEquals "get.pharo.org/vm150" "${vm_url}"
+
+  vm_url="$(pharo::get_vm_url "Pharo32-14")"
+  assertEquals "get.pharo.org/vm140" "${vm_url}"
 
   vm_url="$(pharo::get_vm_url "Pharo32-13")"
   assertEquals "get.pharo.org/vm130" "${vm_url}"


### PR DESCRIPTION
Also cleans up unsupported versions. Specifically, downloads for 64-bit VMs and images are only available starting with Pharo version 9.0.